### PR TITLE
force signing with github private sigstore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
           echo "sha-256=${SHA_256}" >> "$GITHUB_OUTPUT"
       - name: Run attest
         id: attest
+        env:
+          INPUT_PRIVATE-SIGNING: 'true'
         uses: ./
         with:
           subject-name: 'https://api.github.com${{ env.SUBJECT }}'


### PR DESCRIPTION
When this repo flips to public, make sure that the the CI tests still use the private instance