### PR TITLE
update release instructions

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,7 @@
 
 Follow the steps below to tag a new release for the `actions/attest` action.
 
+1. Update the `version` field in package.json.
 1. Merge the latest changes to the `main` branch.
 1. Create a new release using a tag of the form `vX.X.X` following SemVer
    conventions:

--- a/package.json
+++ b/package.json
@@ -1,21 +1,20 @@
 {
-  "name": "typescript-action",
-  "description": "GitHub Actions TypeScript template",
-  "version": "0.0.0",
+  "name": "actions/attest",
+  "description": "Generate signed attestations for workflow artifacts",
+  "version": "0.1.1",
   "author": "",
   "private": true,
-  "homepage": "https://github.com/actions/typescript-action",
+  "homepage": "https://github.com/actions/attest",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/actions/typescript-action.git"
+    "url": "git+https://github.com/actions/attest.git"
   },
   "bugs": {
-    "url": "https://github.com/actions/typescript-action/issues"
+    "url": "https://github.com/actions/attest/issues"
   },
   "keywords": [
     "actions",
-    "node",
-    "setup"
+    "attestation"
   ],
   "exports": {
     ".": "./dist/index.js"


### PR DESCRIPTION
Update the release instructions to remind developers to keep the `version` field in the package.json file up to date.

Also cleans-up some metadata in the package.json