### PR TITLE
tweak summary output

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -79657,6 +79657,7 @@ async function run() {
         ? 'public-good'
         : 'github';
     try {
+        const atts = [];
         if (!process.env.ACTIONS_ID_TOKEN_REQUEST_URL) {
             throw new Error('missing "id-token" permission. Please add "permissions: id-token: write" to your workflow.');
         }
@@ -79673,11 +79674,16 @@ async function run() {
                 flag: 'a'
             });
             if (att.attestationID) {
-                core.summary.addLink(`${subject.name}@${subjectDigest(subject)}`, attestationURL(att.attestationID));
+                atts.push({ subject, attestationID: att.attestationID });
             }
         }
-        if (!core.summary.isEmptyBuffer()) {
-            core.summary.addHeading('Attestation(s) Created', 3);
+        if (atts.length > 0) {
+            core.summary.addHeading(
+            /* istanbul ignore next */
+            atts.length > 1 ? 'Attestations Created' : 'Attestation Created', 3);
+            for (const { subject, attestationID } of atts) {
+                core.summary.addLink(`${subject.name}@${subjectDigest(subject)}`, attestationURL(attestationID));
+            }
             core.summary.write();
         }
         core.setOutput('bundle-path', outputPath);


### PR DESCRIPTION
Updates the summary output which is generated as part of the action run:

Currently, the heading is rendered below the link:
<img width="749" alt="image" src="https://github.com/actions/attest/assets/398027/d711580e-884c-4a63-9ce3-c4c562e8f516">

This change will cause the heading to appear above the link:

<img width="759" alt="image" src="https://github.com/actions/attest/assets/398027/595e93bb-721f-42d9-a02d-f373470bcecf">
