### PR TITLE
limit attestation subject count

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ See [action.yml](action.yml)
   with:
     # Path to the artifact serving as the subject of the attestation. Must
     # specify exactly one of "subject-path" or "subject-digest". May contain
-    # a glob pattern or list of paths.
+    # a glob pattern or list of paths (total subject count cannot exceed 64).
     subject-path:
 
     # SHA256 digest of the subject for for the attestation. Must be in the form

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: >
       Path to the artifact serving as the subject of the attestation. Must
       specify exactly one of "subject-path" or "subject-digest". May contain a
-      glob pattern or list of paths.
+      glob pattern or list of paths (total subject count cannot exceed 64).
     required: false
   subject-digest:
     description: >

--- a/dist/index.js
+++ b/dist/index.js
@@ -79644,6 +79644,7 @@ const subject_1 = __nccwpck_require__(95206);
 const COLOR_CYAN = '\x1B[36m';
 const COLOR_DEFAULT = '\x1B[39m';
 const ATTESTATION_FILE_NAME = 'attestation.jsonl';
+const MAX_SUBJECT_COUNT = 64;
 /**
  * The main function for the action.
  * @returns {Promise<void>} Resolves when the action is complete.
@@ -79661,8 +79662,11 @@ async function run() {
         if (!process.env.ACTIONS_ID_TOKEN_REQUEST_URL) {
             throw new Error('missing "id-token" permission. Please add "permissions: id-token: write" to your workflow.');
         }
-        // Calculate subject from inputs and generate provenance
+        // Gather list of subjets
         const subjects = await (0, subject_1.subjectFromInputs)();
+        if (subjects.length > MAX_SUBJECT_COUNT) {
+            throw new Error(`Too many subjects specified. The maximum number of subjects is ${MAX_SUBJECT_COUNT}.`);
+        }
         const predicate = (0, predicate_1.predicateFromInputs)();
         const outputPath = path_1.default.join(tempDir(), ATTESTATION_FILE_NAME);
         // Generate attestations for each subject serially

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,8 @@ const COLOR_CYAN = '\x1B[36m'
 const COLOR_DEFAULT = '\x1B[39m'
 const ATTESTATION_FILE_NAME = 'attestation.jsonl'
 
+const MAX_SUBJECT_COUNT = 64
+
 /**
  * The main function for the action.
  * @returns {Promise<void>} Resolves when the action is complete.
@@ -38,8 +40,14 @@ export async function run(): Promise<void> {
       )
     }
 
-    // Calculate subject from inputs and generate provenance
+    // Gather list of subjets
     const subjects = await subjectFromInputs()
+    if (subjects.length > MAX_SUBJECT_COUNT) {
+      throw new Error(
+        `Too many subjects specified. The maximum number of subjects is ${MAX_SUBJECT_COUNT}.`
+      )
+    }
+
     const predicate = predicateFromInputs()
     const outputPath = path.join(tempDir(), ATTESTATION_FILE_NAME)
 


### PR DESCRIPTION
Limits the number of subjects which can be attested at one time to 64.

After evaluating the `subject-path` list and resolving any file globs, if the total number of subjects exceeds 64 an error will be returned.