### PR TITLE
ensure subject globs match only files

### DIFF
--- a/__tests__/subject.test.ts
+++ b/__tests__/subject.test.ts
@@ -203,6 +203,19 @@ describe('subjectFromInputs', () => {
       })
     })
 
+    describe('when a file glob is supplied which also matches non-files', () => {
+      beforeEach(async () => {
+        process.env['INPUT_SUBJECT-PATH'] = `${dir}*`
+      })
+
+      it('returns the subjects (excluding non-files)', async () => {
+        const subjects = await subjectFromInputs()
+
+        expect(subjects).toBeDefined()
+        expect(subjects).toHaveLength(7)
+      })
+    })
+
     describe('when a comma-separated list is supplied', () => {
       beforeEach(async () => {
         process.env['INPUT_SUBJECT-PATH'] =

--- a/dist/index.js
+++ b/dist/index.js
@@ -79893,6 +79893,10 @@ const getSubjectFromPath = async (subjectPath, subjectName) => {
         /* eslint-disable-next-line github/no-then */
         const files = await glob.create(subPath).then(async (g) => g.glob());
         for (const file of files) {
+            // Skip anything that is NOT a file
+            if (!fs_1.default.statSync(file).isFile()) {
+                continue;
+            }
             const name = subjectName || path_1.default.parse(file).base;
             const digest = await digestFile(DIGEST_ALGORITHM, file);
             subjects.push({ name, digest: { [DIGEST_ALGORITHM]: digest } });

--- a/src/subject.ts
+++ b/src/subject.ts
@@ -56,6 +56,11 @@ const getSubjectFromPath = async (
     const files = await glob.create(subPath).then(async g => g.glob())
 
     for (const file of files) {
+      // Skip anything that is NOT a file
+      if (!fs.statSync(file).isFile()) {
+        continue
+      }
+
       const name = subjectName || path.parse(file).base
       const digest = await digestFile(DIGEST_ALGORITHM, file)
 


### PR DESCRIPTION
When processing the `subject-path` input, ensure that the artifact being hashed is actually a file. This will help to avoid errors in situations where a file glob matches a directory.