### PR TITLE
bump @sigstore/sign from 2.3.0 to 2.3.1

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13923,8 +13923,23 @@ exports.internalError = internalError;
 
 "use strict";
 
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.checkStatus = exports.HTTPError = void 0;
+exports.HTTPError = void 0;
 class HTTPError extends Error {
     constructor({ status, message, location, }) {
         super(`(${status}) ${message}`);
@@ -13933,38 +13948,11 @@ class HTTPError extends Error {
     }
 }
 exports.HTTPError = HTTPError;
-const checkStatus = async (response) => {
-    if (response.ok) {
-        return response;
-    }
-    else {
-        let message = response.statusText;
-        const location = response.headers?.get('Location') || undefined;
-        const contentType = response.headers?.get('Content-Type');
-        // If response type is JSON, try to parse the body for a message
-        if (contentType?.includes('application/json')) {
-            try {
-                await response.json().then((body) => {
-                    message = body.message;
-                });
-            }
-            catch (e) {
-                // ignore
-            }
-        }
-        throw new HTTPError({
-            status: response.status,
-            message: message,
-            location: location,
-        });
-    }
-};
-exports.checkStatus = checkStatus;
 
 
 /***/ }),
 
-/***/ 62960:
+/***/ 78509:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -13972,6 +13960,110 @@ exports.checkStatus = checkStatus;
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.fetchWithRetry = void 0;
+/*
+Copyright 2023 The Sigstore Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+const http2_1 = __nccwpck_require__(85158);
+const make_fetch_happen_1 = __importDefault(__nccwpck_require__(9525));
+const proc_log_1 = __nccwpck_require__(56528);
+const promise_retry_1 = __importDefault(__nccwpck_require__(54742));
+const util_1 = __nccwpck_require__(90724);
+const error_1 = __nccwpck_require__(11294);
+const { HTTP2_HEADER_LOCATION, HTTP2_HEADER_CONTENT_TYPE, HTTP2_HEADER_USER_AGENT, HTTP_STATUS_INTERNAL_SERVER_ERROR, HTTP_STATUS_TOO_MANY_REQUESTS, HTTP_STATUS_REQUEST_TIMEOUT, } = http2_1.constants;
+async function fetchWithRetry(url, options) {
+    return (0, promise_retry_1.default)(async (retry, attemptNum) => {
+        const method = options.method || 'POST';
+        const headers = {
+            [HTTP2_HEADER_USER_AGENT]: util_1.ua.getUserAgent(),
+            ...options.headers,
+        };
+        const response = await (0, make_fetch_happen_1.default)(url, {
+            method,
+            headers,
+            body: options.body,
+            timeout: options.timeout,
+            retry: false, // We're handling retries ourselves
+        }).catch((reason) => {
+            proc_log_1.log.http('fetch', `${method} ${url} attempt ${attemptNum} failed with ${reason}`);
+            return retry(reason);
+        });
+        if (response.ok) {
+            return response;
+        }
+        else {
+            const error = await errorFromResponse(response);
+            proc_log_1.log.http('fetch', `${method} ${url} attempt ${attemptNum} failed with ${response.status}`);
+            if (retryable(response.status)) {
+                return retry(error);
+            }
+            else {
+                throw error;
+            }
+        }
+    }, retryOpts(options.retry));
+}
+exports.fetchWithRetry = fetchWithRetry;
+// Translate a Response into an HTTPError instance. This will attempt to parse
+// the response body for a message, but will default to the statusText if none
+// is found.
+const errorFromResponse = async (response) => {
+    let message = response.statusText;
+    const location = response.headers?.get(HTTP2_HEADER_LOCATION) || undefined;
+    const contentType = response.headers?.get(HTTP2_HEADER_CONTENT_TYPE);
+    // If response type is JSON, try to parse the body for a message
+    if (contentType?.includes('application/json')) {
+        try {
+            const body = await response.json();
+            message = body.message || message;
+        }
+        catch (e) {
+            // ignore
+        }
+    }
+    return new error_1.HTTPError({
+        status: response.status,
+        message: message,
+        location: location,
+    });
+};
+// Determine if a status code is retryable. This includes 5xx errors, 408, and
+// 429.
+const retryable = (status) => [HTTP_STATUS_REQUEST_TIMEOUT, HTTP_STATUS_TOO_MANY_REQUESTS].includes(status) || status >= HTTP_STATUS_INTERNAL_SERVER_ERROR;
+// Normalize the retry options to the format expected by promise-retry
+const retryOpts = (retry) => {
+    if (typeof retry === 'boolean') {
+        return { retries: retry ? 1 : 0 };
+    }
+    else if (typeof retry === 'number') {
+        return { retries: retry };
+    }
+    else {
+        return { retries: 0, ...retry };
+    }
+};
+
+
+/***/ }),
+
+/***/ 62960:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Fulcio = void 0;
 /*
@@ -13989,33 +14081,26 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-const make_fetch_happen_1 = __importDefault(__nccwpck_require__(9525));
-const util_1 = __nccwpck_require__(90724);
-const error_1 = __nccwpck_require__(11294);
+const fetch_1 = __nccwpck_require__(78509);
 /**
  * Fulcio API client.
  */
 class Fulcio {
     constructor(options) {
-        this.fetch = make_fetch_happen_1.default.defaults({
-            retry: options.retry,
-            timeout: options.timeout,
-            headers: {
-                'Content-Type': 'application/json',
-                'User-Agent': util_1.ua.getUserAgent(),
-            },
-        });
-        this.baseUrl = options.baseURL;
+        this.options = options;
     }
     async createSigningCertificate(request) {
-        const url = `${this.baseUrl}/api/v2/signingCert`;
-        const response = await this.fetch(url, {
-            method: 'POST',
+        const { baseURL, retry, timeout } = this.options;
+        const url = `${baseURL}/api/v2/signingCert`;
+        const response = await (0, fetch_1.fetchWithRetry)(url, {
+            headers: {
+                'Content-Type': 'application/json',
+            },
             body: JSON.stringify(request),
+            timeout,
+            retry,
         });
-        await (0, error_1.checkStatus)(response);
-        const data = await response.json();
-        return data;
+        return response.json();
     }
 }
 exports.Fulcio = Fulcio;
@@ -14024,13 +14109,10 @@ exports.Fulcio = Fulcio;
 /***/ }),
 
 /***/ 56205:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.Rekor = void 0;
 /*
@@ -14048,23 +14130,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-const make_fetch_happen_1 = __importDefault(__nccwpck_require__(9525));
-const util_1 = __nccwpck_require__(90724);
-const error_1 = __nccwpck_require__(11294);
+const fetch_1 = __nccwpck_require__(78509);
 /**
  * Rekor API client.
  */
 class Rekor {
     constructor(options) {
-        this.fetch = make_fetch_happen_1.default.defaults({
-            retry: options.retry,
-            timeout: options.timeout,
-            headers: {
-                Accept: 'application/json',
-                'User-Agent': util_1.ua.getUserAgent(),
-            },
-        });
-        this.baseUrl = options.baseURL;
+        this.options = options;
     }
     /**
      * Create a new entry in the Rekor log.
@@ -14072,13 +14144,17 @@ class Rekor {
      * @returns {Promise<Entry>} The created entry
      */
     async createEntry(propsedEntry) {
-        const url = `${this.baseUrl}/api/v1/log/entries`;
-        const response = await this.fetch(url, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+        const { baseURL, timeout, retry } = this.options;
+        const url = `${baseURL}/api/v1/log/entries`;
+        const response = await (0, fetch_1.fetchWithRetry)(url, {
+            headers: {
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+            },
             body: JSON.stringify(propsedEntry),
+            timeout,
+            retry,
         });
-        await (0, error_1.checkStatus)(response);
         const data = await response.json();
         return entryFromResponse(data);
     }
@@ -14088,44 +14164,18 @@ class Rekor {
      * @returns {Promise<Entry>} The retrieved entry
      */
     async getEntry(uuid) {
-        const url = `${this.baseUrl}/api/v1/log/entries/${uuid}`;
-        const response = await this.fetch(url);
-        await (0, error_1.checkStatus)(response);
+        const { baseURL, timeout, retry } = this.options;
+        const url = `${baseURL}/api/v1/log/entries/${uuid}`;
+        const response = await (0, fetch_1.fetchWithRetry)(url, {
+            method: 'GET',
+            headers: {
+                Accept: 'application/json',
+            },
+            timeout,
+            retry,
+        });
         const data = await response.json();
         return entryFromResponse(data);
-    }
-    /**
-     * Search the Rekor log index for entries matching the given query.
-     * @param opts {SearchIndex} Options to search the Rekor log
-     * @returns {Promise<string[]>} UUIDs of matching entries
-     */
-    async searchIndex(opts) {
-        const url = `${this.baseUrl}/api/v1/index/retrieve`;
-        const response = await this.fetch(url, {
-            method: 'POST',
-            body: JSON.stringify(opts),
-            headers: { 'Content-Type': 'application/json' },
-        });
-        await (0, error_1.checkStatus)(response);
-        const data = await response.json();
-        return data;
-    }
-    /**
-     * Search the Rekor logs for matching the given query.
-     * @param opts {SearchLogQuery} Query to search the Rekor log
-     * @returns {Promise<Entry[]>} List of matching entries
-     */
-    async searchLog(opts) {
-        const url = `${this.baseUrl}/api/v1/log/entries/retrieve`;
-        const response = await this.fetch(url, {
-            method: 'POST',
-            body: JSON.stringify(opts),
-            headers: { 'Content-Type': 'application/json' },
-        });
-        await (0, error_1.checkStatus)(response);
-        const rawData = await response.json();
-        const data = rawData.map((d) => entryFromResponse(d));
-        return data;
     }
 }
 exports.Rekor = Rekor;
@@ -14147,13 +14197,10 @@ function entryFromResponse(data) {
 /***/ }),
 
 /***/ 82759:
-/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
 
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.TimestampAuthority = void 0;
 /*
@@ -14171,28 +14218,22 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-const make_fetch_happen_1 = __importDefault(__nccwpck_require__(9525));
-const util_1 = __nccwpck_require__(90724);
-const error_1 = __nccwpck_require__(11294);
+const fetch_1 = __nccwpck_require__(78509);
 class TimestampAuthority {
     constructor(options) {
-        this.fetch = make_fetch_happen_1.default.defaults({
-            retry: options.retry,
-            timeout: options.timeout,
-            headers: {
-                'Content-Type': 'application/json',
-                'User-Agent': util_1.ua.getUserAgent(),
-            },
-        });
-        this.baseUrl = options.baseURL;
+        this.options = options;
     }
     async createTimestamp(request) {
-        const url = `${this.baseUrl}/api/v1/timestamp`;
-        const response = await this.fetch(url, {
-            method: 'POST',
+        const { baseURL, timeout, retry } = this.options;
+        const url = `${baseURL}/api/v1/timestamp`;
+        const response = await (0, fetch_1.fetchWithRetry)(url, {
+            headers: {
+                'Content-Type': 'application/json',
+            },
             body: JSON.stringify(request),
+            timeout,
+            retry,
         });
-        await (0, error_1.checkStatus)(response);
         return response.buffer();
     }
 }
@@ -40919,6 +40960,8 @@ class CacheEntry {
       const cacheWritePromise = new Promise((resolve, reject) => {
         cacheWriteResolve = resolve
         cacheWriteReject = reject
+      }).catch((err) => {
+        body.emit('error', err)
       })
 
       body = new CachingMinipassPipeline({ events: ['integrity', 'size'] }, new MinipassFlush({
@@ -41673,6 +41716,7 @@ const { Minipass } = __nccwpck_require__(14968)
 const fetch = __nccwpck_require__(68998)
 const promiseRetry = __nccwpck_require__(54742)
 const ssri = __nccwpck_require__(4406)
+const { log } = __nccwpck_require__(56528)
 
 const CachingMinipassPipeline = __nccwpck_require__(61064)
 const { getAgent } = __nccwpck_require__(79907)
@@ -41760,6 +41804,8 @@ const remoteFetch = (request, options) => {
           options.onRetry(res)
         }
 
+        /* eslint-disable-next-line max-len */
+        log.http('fetch', `${req.method} ${req.url} attempt ${attemptNum} failed with ${res.status}`)
         return retryHandler(res)
       }
 
@@ -41783,6 +41829,7 @@ const remoteFetch = (request, options) => {
         options.onRetry(err)
       }
 
+      log.http('fetch', `${req.method} ${req.url} attempt ${attemptNum} failed with ${err.code}`)
       return retryHandler(err)
     }
   }, options.retry).catch((err) => {
@@ -49020,6 +49067,166 @@ module.exports = async (
 		}
 	});
 };
+
+
+/***/ }),
+
+/***/ 56528:
+/***/ ((module) => {
+
+const META = Symbol('proc-log.meta')
+module.exports = {
+  META: META,
+  output: {
+    LEVELS: [
+      'standard',
+      'error',
+      'buffer',
+      'flush',
+    ],
+    KEYS: {
+      standard: 'standard',
+      error: 'error',
+      buffer: 'buffer',
+      flush: 'flush',
+    },
+    standard: function (...args) {
+      return process.emit('output', 'standard', ...args)
+    },
+    error: function (...args) {
+      return process.emit('output', 'error', ...args)
+    },
+    buffer: function (...args) {
+      return process.emit('output', 'buffer', ...args)
+    },
+    flush: function (...args) {
+      return process.emit('output', 'flush', ...args)
+    },
+  },
+  log: {
+    LEVELS: [
+      'notice',
+      'error',
+      'warn',
+      'info',
+      'verbose',
+      'http',
+      'silly',
+      'timing',
+      'pause',
+      'resume',
+    ],
+    KEYS: {
+      notice: 'notice',
+      error: 'error',
+      warn: 'warn',
+      info: 'info',
+      verbose: 'verbose',
+      http: 'http',
+      silly: 'silly',
+      timing: 'timing',
+      pause: 'pause',
+      resume: 'resume',
+    },
+    error: function (...args) {
+      return process.emit('log', 'error', ...args)
+    },
+    notice: function (...args) {
+      return process.emit('log', 'notice', ...args)
+    },
+    warn: function (...args) {
+      return process.emit('log', 'warn', ...args)
+    },
+    info: function (...args) {
+      return process.emit('log', 'info', ...args)
+    },
+    verbose: function (...args) {
+      return process.emit('log', 'verbose', ...args)
+    },
+    http: function (...args) {
+      return process.emit('log', 'http', ...args)
+    },
+    silly: function (...args) {
+      return process.emit('log', 'silly', ...args)
+    },
+    timing: function (...args) {
+      return process.emit('log', 'timing', ...args)
+    },
+    pause: function () {
+      return process.emit('log', 'pause')
+    },
+    resume: function () {
+      return process.emit('log', 'resume')
+    },
+  },
+  time: {
+    LEVELS: [
+      'start',
+      'end',
+    ],
+    KEYS: {
+      start: 'start',
+      end: 'end',
+    },
+    start: function (name, fn) {
+      process.emit('time', 'start', name)
+      function end () {
+        return process.emit('time', 'end', name)
+      }
+      if (typeof fn === 'function') {
+        const res = fn()
+        if (res && res.finally) {
+          return res.finally(end)
+        }
+        end()
+        return res
+      }
+      return end
+    },
+    end: function (name) {
+      return process.emit('time', 'end', name)
+    },
+  },
+  input: {
+    LEVELS: [
+      'start',
+      'end',
+      'read',
+    ],
+    KEYS: {
+      start: 'start',
+      end: 'end',
+      read: 'read',
+    },
+    start: function (fn) {
+      process.emit('input', 'start')
+      function end () {
+        return process.emit('input', 'end')
+      }
+      if (typeof fn === 'function') {
+        const res = fn()
+        if (res && res.finally) {
+          return res.finally(end)
+        }
+        end()
+        return res
+      }
+      return end
+    },
+    end: function () {
+      return process.emit('input', 'end')
+    },
+    read: function (...args) {
+      let resolve, reject
+      const promise = new Promise((_resolve, _reject) => {
+        resolve = _resolve
+        reject = _reject
+      })
+      process.emit('input', 'read', resolve, reject, ...args)
+      return promise
+    },
+  },
+}
 
 
 /***/ }),
@@ -93860,7 +94067,7 @@ exports.parse = parse;
 /***/ ((module) => {
 
 "use strict";
-module.exports = {"i8":"2.3.0"};
+module.exports = {"i8":"2.3.1"};
 
 /***/ }),
 
@@ -93940,7 +94147,7 @@ module.exports = JSON.parse('[["0","\\u0000",128],["a1","｡",62],["8140","　�
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"name":"make-fetch-happen","version":"13.0.0","description":"Opinionated, caching, retrying fetch client","main":"lib/index.js","files":["bin/","lib/"],"scripts":{"test":"tap","posttest":"npm run lint","eslint":"eslint","lint":"eslint \\"**/*.js\\"","lintfix":"npm run lint -- --fix","postlint":"template-oss-check","snap":"tap","template-oss-apply":"template-oss-apply --force"},"repository":{"type":"git","url":"https://github.com/npm/make-fetch-happen.git"},"keywords":["http","request","fetch","mean girls","caching","cache","subresource integrity"],"author":"GitHub Inc.","license":"ISC","dependencies":{"@npmcli/agent":"^2.0.0","cacache":"^18.0.0","http-cache-semantics":"^4.1.1","is-lambda":"^1.0.1","minipass":"^7.0.2","minipass-fetch":"^3.0.0","minipass-flush":"^1.0.5","minipass-pipeline":"^1.2.4","negotiator":"^0.6.3","promise-retry":"^2.0.1","ssri":"^10.0.0"},"devDependencies":{"@npmcli/eslint-config":"^4.0.0","@npmcli/template-oss":"4.18.0","nock":"^13.2.4","safe-buffer":"^5.2.1","standard-version":"^9.3.2","tap":"^16.0.0"},"engines":{"node":"^16.14.0 || >=18.0.0"},"tap":{"color":1,"files":"test/*.js","check-coverage":true,"timeout":60,"nyc-arg":["--exclude","tap-snapshots/**"]},"templateOSS":{"//@npmcli/template-oss":"This file is partially managed by @npmcli/template-oss. Edits may be overwritten.","ciVersions":["16.14.0","16.x","18.0.0","18.x"],"version":"4.18.0","publish":"true"}}');
+module.exports = JSON.parse('{"name":"make-fetch-happen","version":"13.0.1","description":"Opinionated, caching, retrying fetch client","main":"lib/index.js","files":["bin/","lib/"],"scripts":{"test":"tap","posttest":"npm run lint","eslint":"eslint","lint":"eslint \\"**/*.{js,cjs,ts,mjs,jsx,tsx}\\"","lintfix":"npm run lint -- --fix","postlint":"template-oss-check","snap":"tap","template-oss-apply":"template-oss-apply --force"},"repository":{"type":"git","url":"https://github.com/npm/make-fetch-happen.git"},"keywords":["http","request","fetch","mean girls","caching","cache","subresource integrity"],"author":"GitHub Inc.","license":"ISC","dependencies":{"@npmcli/agent":"^2.0.0","cacache":"^18.0.0","http-cache-semantics":"^4.1.1","is-lambda":"^1.0.1","minipass":"^7.0.2","minipass-fetch":"^3.0.0","minipass-flush":"^1.0.5","minipass-pipeline":"^1.2.4","negotiator":"^0.6.3","proc-log":"^4.2.0","promise-retry":"^2.0.1","ssri":"^10.0.0"},"devDependencies":{"@npmcli/eslint-config":"^4.0.0","@npmcli/template-oss":"4.21.4","nock":"^13.2.4","safe-buffer":"^5.2.1","standard-version":"^9.3.2","tap":"^16.0.0"},"engines":{"node":"^16.14.0 || >=18.0.0"},"tap":{"color":1,"files":"test/*.js","check-coverage":true,"timeout":60,"nyc-arg":["--exclude","tap-snapshots/**"]},"templateOSS":{"//@npmcli/template-oss":"This file is partially managed by @npmcli/template-oss. Edits may be overwritten.","version":"4.21.4","publish":"true"}}');
 
 /***/ }),
 

--- a/dist/licenses.txt
+++ b/dist/licenses.txt
@@ -2887,6 +2887,25 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 
+proc-log
+ISC
+The ISC License
+
+Copyright (c) GitHub, Inc.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
 promise-retry
 MIT
 Copyright (c) 2014 IndigoUnited

--- a/package-lock.json
+++ b/package-lock.json
@@ -1748,14 +1748,16 @@
       }
     },
     "node_modules/@sigstore/sign": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.3.0.tgz",
-      "integrity": "sha512-tsAyV6FC3R3pHmKS880IXcDJuiFJiKITO1jxR1qbplcsBkZLBmjrEw5GbC7ikD6f5RU1hr7WnmxB/2kKc1qUWQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.3.1.tgz",
+      "integrity": "sha512-YZ71wKIOweC8ViUeZXboz0iPLqMkskxuoeN/D1CEpAyZvEepbX9oRMIoO6a/DxUqO1VEaqmcmmqzSiqtOsvSmw==",
       "dependencies": {
         "@sigstore/bundle": "^2.3.0",
         "@sigstore/core": "^1.0.0",
         "@sigstore/protobuf-specs": "^0.3.1",
-        "make-fetch-happen": "^13.0.0"
+        "make-fetch-happen": "^13.0.1",
+        "proc-log": "^4.2.0",
+        "promise-retry": "^2.0.1"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -6309,8 +6311,9 @@
       "license": "ISC"
     },
     "node_modules/make-fetch-happen": {
-      "version": "13.0.0",
-      "license": "ISC",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
+      "integrity": "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==",
       "dependencies": {
         "@npmcli/agent": "^2.0.0",
         "cacache": "^18.0.0",
@@ -6321,6 +6324,7 @@
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "negotiator": "^0.6.3",
+        "proc-log": "^4.2.0",
         "promise-retry": "^2.0.1",
         "ssri": "^10.0.0"
       },
@@ -7316,6 +7320,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/promise-retry": {
@@ -9920,14 +9932,16 @@
       "integrity": "sha512-aIL8Z9NsMr3C64jyQzE0XlkEyBLpgEJJFDHLVVStkFV5Q3Il/r/YtY6NJWKQ4cy4AE7spP1IX5Jq7VCAxHHMfQ=="
     },
     "@sigstore/sign": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.3.0.tgz",
-      "integrity": "sha512-tsAyV6FC3R3pHmKS880IXcDJuiFJiKITO1jxR1qbplcsBkZLBmjrEw5GbC7ikD6f5RU1hr7WnmxB/2kKc1qUWQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.3.1.tgz",
+      "integrity": "sha512-YZ71wKIOweC8ViUeZXboz0iPLqMkskxuoeN/D1CEpAyZvEepbX9oRMIoO6a/DxUqO1VEaqmcmmqzSiqtOsvSmw==",
       "requires": {
         "@sigstore/bundle": "^2.3.0",
         "@sigstore/core": "^1.0.0",
         "@sigstore/protobuf-specs": "^0.3.1",
-        "make-fetch-happen": "^13.0.0"
+        "make-fetch-happen": "^13.0.1",
+        "proc-log": "^4.2.0",
+        "promise-retry": "^2.0.1"
       }
     },
     "@sinclair/typebox": {
@@ -13031,7 +13045,9 @@
       "dev": true
     },
     "make-fetch-happen": {
-      "version": "13.0.0",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
+      "integrity": "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==",
       "requires": {
         "@npmcli/agent": "^2.0.0",
         "cacache": "^18.0.0",
@@ -13042,6 +13058,7 @@
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "negotiator": "^0.6.3",
+        "proc-log": "^4.2.0",
         "promise-retry": "^2.0.1",
         "ssri": "^10.0.0"
       }
@@ -13668,6 +13685,11 @@
           "dev": true
         }
       }
+    },
+    "proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA=="
     },
     "promise-retry": {
       "version": "2.0.1",


### PR DESCRIPTION
Update `@sigstore/sign` from v2.3.0 to v2.3.1.

Fixes bug preventing failed API requests from being retried.