### PR TITLE
include more detail in error logging

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -116,7 +116,9 @@ describe('action', () => {
 
       expect(runMock).toHaveReturned()
       expect(setFailedMock).toHaveBeenCalledWith(
-        expect.stringMatching(/missing "id-token" permission/)
+        new Error(
+          'missing "id-token" permission. Please add "permissions: id-token: write" to your workflow.'
+        )
       )
     })
   })
@@ -131,9 +133,7 @@ describe('action', () => {
 
       expect(runMock).toHaveReturned()
       expect(setFailedMock).toHaveBeenCalledWith(
-        expect.stringMatching(
-          /one of subject-path or subject-digest must be provided/i
-        )
+        new Error('One of subject-path or subject-digest must be provided')
       )
     })
   })
@@ -330,7 +330,9 @@ describe('action', () => {
 
       expect(runMock).toHaveReturned()
       expect(setFailedMock).toHaveBeenCalledWith(
-        'Too many subjects specified. The maximum number of subjects is 64.'
+        new Error(
+          'Too many subjects specified. The maximum number of subjects is 64.'
+        )
       )
     })
   })

--- a/dist/index.js
+++ b/dist/index.js
@@ -79642,6 +79642,7 @@ const endpoints_1 = __nccwpck_require__(69112);
 const predicate_1 = __nccwpck_require__(72103);
 const subject_1 = __nccwpck_require__(95206);
 const COLOR_CYAN = '\x1B[36m';
+const COLOR_GRAY = '\x1B[38;5;244m';
 const COLOR_DEFAULT = '\x1B[39m';
 const ATTESTATION_FILE_NAME = 'attestation.jsonl';
 const MAX_SUBJECT_COUNT = 64;
@@ -79694,11 +79695,12 @@ async function run() {
     }
     catch (err) {
         // Fail the workflow run if an error occurs
-        core.setFailed(err instanceof Error ? err.message : /* istanbul ignore next */ `${err}`);
+        core.setFailed(err instanceof Error ? err : /* istanbul ignore next */ `${err}`);
+        // Log the cause of the error if one is available
         /* istanbul ignore if */
         if (err instanceof Error && 'cause' in err) {
             const innerErr = err.cause;
-            core.debug(innerErr instanceof Error ? innerErr.message : `${innerErr}}`);
+            core.info(mute(innerErr instanceof Error ? innerErr.toString() : `${innerErr}`));
         }
     }
 }
@@ -79744,7 +79746,11 @@ const createAttestation = async (subject, predicate, sigstoreInstance) => {
     }
     return attestation;
 };
+// Emphasis string using ANSI color codes
 const highlight = (str) => `${COLOR_CYAN}${str}${COLOR_DEFAULT}`;
+// De-emphasize string using ANSI color codes
+/* istanbul ignore next */
+const mute = (str) => `${COLOR_GRAY}${str}${COLOR_DEFAULT}`;
 const tempDir = () => {
     const basePath = process.env['RUNNER_TEMP'];
     /* istanbul ignore if */

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ type SigstoreInstance = 'public-good' | 'github'
 type AttestedSubject = { subject: Subject; attestationID: string }
 
 const COLOR_CYAN = '\x1B[36m'
+const COLOR_GRAY = '\x1B[38;5;244m'
 const COLOR_DEFAULT = '\x1B[39m'
 const ATTESTATION_FILE_NAME = 'attestation.jsonl'
 
@@ -86,13 +87,16 @@ export async function run(): Promise<void> {
   } catch (err) {
     // Fail the workflow run if an error occurs
     core.setFailed(
-      err instanceof Error ? err.message : /* istanbul ignore next */ `${err}`
+      err instanceof Error ? err : /* istanbul ignore next */ `${err}`
     )
 
+    // Log the cause of the error if one is available
     /* istanbul ignore if */
     if (err instanceof Error && 'cause' in err) {
       const innerErr = err.cause
-      core.debug(innerErr instanceof Error ? innerErr.message : `${innerErr}}`)
+      core.info(
+        mute(innerErr instanceof Error ? innerErr.toString() : `${innerErr}`)
+      )
     }
   }
 }
@@ -156,7 +160,12 @@ const createAttestation = async (
   return attestation
 }
 
+// Emphasis string using ANSI color codes
 const highlight = (str: string): string => `${COLOR_CYAN}${str}${COLOR_DEFAULT}`
+
+// De-emphasize string using ANSI color codes
+/* istanbul ignore next */
+const mute = (str: string): string => `${COLOR_GRAY}${str}${COLOR_DEFAULT}`
 
 const tempDir = (): string => {
   const basePath = process.env['RUNNER_TEMP']


### PR DESCRIPTION
Improves the error logging to include the name of the specific error which was thrown as well as details about any wrapped errors (if available). Previously, the user would have to enable [step debug logging](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging#enabling-step-debug-logging) to get this level of detail.

Before:

<img width="330" alt="image" src="https://github.com/actions/attest/assets/398027/8560e296-debd-42d7-8cbe-86ab23251c9c">

After:

<img width="585" alt="image" src="https://github.com/actions/attest/assets/398027/47b48de2-a01d-492b-bf71-9f8e132b6dc2">
