### PR TITLE
bump @sigstore/oci from 0.3.0 to 0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@actions/attest": "^1.2.1",
         "@actions/core": "^1.10.1",
         "@actions/glob": "^0.4.0",
-        "@sigstore/oci": "^0.3.0",
+        "@sigstore/oci": "^0.3.2",
         "csv-parse": "^5.5.5"
       },
       "devDependencies": {
@@ -1729,11 +1729,12 @@
       }
     },
     "node_modules/@sigstore/oci": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/oci/-/oci-0.3.0.tgz",
-      "integrity": "sha512-RZeirZtdSQvBC04j+rvPwBOnzMsc1NC3Ucx4krSh37Ch/Z1BwwAEV3QDQ18McXX2Guvc2pnWeGd6RXn+vpivww==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@sigstore/oci/-/oci-0.3.2.tgz",
+      "integrity": "sha512-3UJC2SV+A4HuILse/jvodDI+0QIN13fErxu3roX5HU9wOeP31UHH/WMQBlN3l5DVewXTufNs3Q85DzOI1tQNLQ==",
       "dependencies": {
-        "make-fetch-happen": "^13.0.0"
+        "make-fetch-happen": "^13.0.1",
+        "proc-log": "^4.2.0"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -9919,11 +9920,12 @@
       }
     },
     "@sigstore/oci": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/oci/-/oci-0.3.0.tgz",
-      "integrity": "sha512-RZeirZtdSQvBC04j+rvPwBOnzMsc1NC3Ucx4krSh37Ch/Z1BwwAEV3QDQ18McXX2Guvc2pnWeGd6RXn+vpivww==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@sigstore/oci/-/oci-0.3.2.tgz",
+      "integrity": "sha512-3UJC2SV+A4HuILse/jvodDI+0QIN13fErxu3roX5HU9wOeP31UHH/WMQBlN3l5DVewXTufNs3Q85DzOI1tQNLQ==",
       "requires": {
-        "make-fetch-happen": "^13.0.0"
+        "make-fetch-happen": "^13.0.1",
+        "proc-log": "^4.2.0"
       }
     },
     "@sigstore/protobuf-specs": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@actions/attest": "^1.2.1",
     "@actions/core": "^1.10.1",
     "@actions/glob": "^0.4.0",
-    "@sigstore/oci": "^0.3.0",
+    "@sigstore/oci": "^0.3.2",
     "csv-parse": "^5.5.5"
   },
   "devDependencies": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,9 @@ const ATTESTATION_FILE_NAME = 'attestation.jsonl'
 
 const MAX_SUBJECT_COUNT = 64
 
+const OCI_TIMEOUT = 2000
+const OCI_RETRY = 3
+
 /* istanbul ignore next */
 const logHandler = (level: string, ...args: unknown[]): void => {
   // Send any HTTP-related log events to the GitHub Actions debug log
@@ -163,7 +166,8 @@ const createAttestation = async (
       annotations: {
         'dev.sigstore.bundle.content': 'dsse-envelope',
         'dev.sigstore.bundle.predicateType': core.getInput('predicate-type')
-      }
+      },
+      fetchOpts: { timeout: OCI_TIMEOUT, retry: OCI_RETRY }
     })
     core.info(highlight('Attestation uploaded to registry'))
     core.info(`${subject.name}@${artifact.digest}`)


### PR DESCRIPTION
Update `@sigstore/oci` from v0.3.0 to v0.3.2.

Fixes bug preventing failed API requests from being retried.