### PR TITLE
downcase subject name for OCI images

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -80186,6 +80186,9 @@ const subjectFromInputs = async () => {
     const subjectPath = core.getInput('subject-path', { required: false });
     const subjectDigest = core.getInput('subject-digest', { required: false });
     const subjectName = core.getInput('subject-name', { required: false });
+    const pushToRegistry = core.getBooleanInput('push-to-registry', {
+        required: false
+    });
     if (!subjectPath && !subjectDigest) {
         throw new Error('One of subject-path or subject-digest must be provided');
     }
@@ -80195,11 +80198,14 @@ const subjectFromInputs = async () => {
     if (subjectDigest && !subjectName) {
         throw new Error('subject-name must be provided when using subject-digest');
     }
+    // If push-to-registry is enabled, ensure the subject name is lowercase
+    // to conform to OCI image naming conventions
+    const name = pushToRegistry ? subjectName.toLowerCase() : subjectName;
     if (subjectPath) {
-        return await getSubjectFromPath(subjectPath, subjectName);
+        return await getSubjectFromPath(subjectPath, name);
     }
     else {
-        return [getSubjectFromDigest(subjectDigest, subjectName)];
+        return [getSubjectFromDigest(subjectDigest, name)];
     }
 };
 exports.subjectFromInputs = subjectFromInputs;

--- a/src/subject.ts
+++ b/src/subject.ts
@@ -17,6 +17,9 @@ export const subjectFromInputs = async (): Promise<Subject[]> => {
   const subjectPath = core.getInput('subject-path', { required: false })
   const subjectDigest = core.getInput('subject-digest', { required: false })
   const subjectName = core.getInput('subject-name', { required: false })
+  const pushToRegistry = core.getBooleanInput('push-to-registry', {
+    required: false
+  })
 
   if (!subjectPath && !subjectDigest) {
     throw new Error('One of subject-path or subject-digest must be provided')
@@ -32,10 +35,14 @@ export const subjectFromInputs = async (): Promise<Subject[]> => {
     throw new Error('subject-name must be provided when using subject-digest')
   }
 
+  // If push-to-registry is enabled, ensure the subject name is lowercase
+  // to conform to OCI image naming conventions
+  const name = pushToRegistry ? subjectName.toLowerCase() : subjectName
+
   if (subjectPath) {
-    return await getSubjectFromPath(subjectPath, subjectName)
+    return await getSubjectFromPath(subjectPath, name)
   } else {
-    return [getSubjectFromDigest(subjectDigest, subjectName)]
+    return [getSubjectFromDigest(subjectDigest, name)]
   }
 }
 


### PR DESCRIPTION
Automatically downcases the subject name when the `push-to-registry` flag is supplied. The OCI spec requires that the image repository name be all lower-case, so any time a user is pushing an attestation to a registry the subject name MUST conform to the OCI spec.

This is mainly a problem when the GitHub repository name is used as the repository name with something like this:

```yaml
- name: Attest Build Provenance
  uses: actions/attest-build-provenance@v1
  with:
    subject-name: ghcr.io/${{ github.repository }}
    subject-digest: ${{ steps.build-and-push.outputs.digest }}
    push-to-registry: true
```

If the GH repository name happens to contain uppercase characters this will fail.

The change made here will ensure that this use case will succeed even if the GH repo name contains uppercase characters.

It's worth noting that the `docker/metadata-action` and `docker/buid-push-action` actions perform a similar transformation on the input to ensure a valid image name.

See: https://github.com/actions/attest-build-provenance/issues/71