### PR TITLE
Bump @sigstore/oci from 0.3.2 to 0.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ fully-qualified image name (e.g. "ghcr.io/user/app" or
 "acme.azurecr.io/user/app"). Do NOT include a tag as part of the image name --
 the specific image being attested is identified by the supplied digest.
 
-> **NOTE**: When pushing to Docker Hub, please use "index.docker.io" as the
+> **NOTE**: When pushing to Docker Hub, please use "docker.io" as the
 > registry portion of the image name.
 
 ```yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "actions/attest",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "actions/attest",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@actions/attest": "^1.2.1",
         "@actions/core": "^1.10.1",
         "@actions/glob": "^0.4.0",
-        "@sigstore/oci": "^0.3.2",
+        "@sigstore/oci": "^0.3.3",
         "csv-parse": "^5.5.5"
       },
       "devDependencies": {
@@ -1729,9 +1729,9 @@
       }
     },
     "node_modules/@sigstore/oci": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@sigstore/oci/-/oci-0.3.2.tgz",
-      "integrity": "sha512-3UJC2SV+A4HuILse/jvodDI+0QIN13fErxu3roX5HU9wOeP31UHH/WMQBlN3l5DVewXTufNs3Q85DzOI1tQNLQ==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@sigstore/oci/-/oci-0.3.3.tgz",
+      "integrity": "sha512-GFNS7BVC0YvZnajj/ZtboH98A8T0rApkkI3988BzkuIJ5f3Z+mTXr/b5K7OekfHv7LvLzSziXXRRnsb6Cx8zXg==",
       "dependencies": {
         "make-fetch-happen": "^13.0.1",
         "proc-log": "^4.2.0"
@@ -9805,9 +9805,9 @@
       }
     },
     "@sigstore/oci": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@sigstore/oci/-/oci-0.3.2.tgz",
-      "integrity": "sha512-3UJC2SV+A4HuILse/jvodDI+0QIN13fErxu3roX5HU9wOeP31UHH/WMQBlN3l5DVewXTufNs3Q85DzOI1tQNLQ==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@sigstore/oci/-/oci-0.3.3.tgz",
+      "integrity": "sha512-GFNS7BVC0YvZnajj/ZtboH98A8T0rApkkI3988BzkuIJ5f3Z+mTXr/b5K7OekfHv7LvLzSziXXRRnsb6Cx8zXg==",
       "requires": {
         "make-fetch-happen": "^13.0.1",
         "proc-log": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "actions/attest",
   "description": "Generate signed attestations for workflow artifacts",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": "",
   "private": true,
   "homepage": "https://github.com/actions/attest",
@@ -72,7 +72,7 @@
     "@actions/attest": "^1.2.1",
     "@actions/core": "^1.10.1",
     "@actions/glob": "^0.4.0",
-    "@sigstore/oci": "^0.3.2",
+    "@sigstore/oci": "^0.3.3",
     "csv-parse": "^5.5.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates the `@sigstore/oci` package from version 0.3.2 to 0.3.3. Includes the following fixes:

* Fix accept header when retrieving image manifest
* Support variants of the Docker Hub registry name