### PR TITLE
bump @sigstore/oci from 0.3.3 to 0.3.4

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11814,7 +11814,7 @@ async function _OCIImage_createReferrersIndexByTag(opts) {
     if (!referrerManifest.manifests.some((manifest) => manifest.digest === opts.artifact.digest)) {
         // Add the artifact to the index
         referrerManifest.manifests.push(opts.artifact);
-        __classPrivateFieldGet(this, _OCIImage_client, "f").uploadManifest(JSON.stringify(referrerManifest), {
+        await __classPrivateFieldGet(this, _OCIImage_client, "f").uploadManifest(JSON.stringify(referrerManifest), {
             mediaType: constants_1.CONTENT_TYPE_OCI_INDEX,
             reference: referrerTag,
             etag,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@actions/attest": "^1.2.1",
         "@actions/core": "^1.10.1",
         "@actions/glob": "^0.4.0",
-        "@sigstore/oci": "^0.3.3",
+        "@sigstore/oci": "^0.3.4",
         "csv-parse": "^5.5.6"
       },
       "devDependencies": {
@@ -1729,9 +1729,9 @@
       }
     },
     "node_modules/@sigstore/oci": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@sigstore/oci/-/oci-0.3.3.tgz",
-      "integrity": "sha512-GFNS7BVC0YvZnajj/ZtboH98A8T0rApkkI3988BzkuIJ5f3Z+mTXr/b5K7OekfHv7LvLzSziXXRRnsb6Cx8zXg==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@sigstore/oci/-/oci-0.3.4.tgz",
+      "integrity": "sha512-ydRTsvHOmLWnlR2BTtG1pHYvLkHG/oaqVyd2WDkfLU7B3dIWfqavE80VCzidNWuZpXN7m8+uBNatus2Qva1ktA==",
       "dependencies": {
         "make-fetch-happen": "^13.0.1",
         "proc-log": "^4.2.0"
@@ -9805,9 +9805,9 @@
       }
     },
     "@sigstore/oci": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@sigstore/oci/-/oci-0.3.3.tgz",
-      "integrity": "sha512-GFNS7BVC0YvZnajj/ZtboH98A8T0rApkkI3988BzkuIJ5f3Z+mTXr/b5K7OekfHv7LvLzSziXXRRnsb6Cx8zXg==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@sigstore/oci/-/oci-0.3.4.tgz",
+      "integrity": "sha512-ydRTsvHOmLWnlR2BTtG1pHYvLkHG/oaqVyd2WDkfLU7B3dIWfqavE80VCzidNWuZpXN7m8+uBNatus2Qva1ktA==",
       "requires": {
         "make-fetch-happen": "^13.0.1",
         "proc-log": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@actions/attest": "^1.2.1",
     "@actions/core": "^1.10.1",
     "@actions/glob": "^0.4.0",
-    "@sigstore/oci": "^0.3.3",
+    "@sigstore/oci": "^0.3.4",
     "csv-parse": "^5.5.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Bump `@sigstore/oci` from 0.3.3 to [0.3.4](https://github.com/sigstore/sigstore-js/releases/tag/%40sigstore%2Foci%400.3.4).