### PR TITLE
centralize collection of action inputs

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -2,12 +2,17 @@
  * Unit tests for the action's entrypoint, src/index.ts
  */
 
+import * as core from '@actions/core'
 import * as main from '../src/main'
 
 // Mock the action's entrypoint
 const runMock = jest.spyOn(main, 'run').mockImplementation()
+const getBooleanInputMock = jest.spyOn(core, 'getBooleanInput')
 
 describe('index', () => {
+  beforeEach(() => {
+    getBooleanInputMock.mockImplementation(() => false)
+  })
   it('calls run when imported', async () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     require('../src/index')

--- a/__tests__/predicate.test.ts
+++ b/__tests__/predicate.test.ts
@@ -1,91 +1,97 @@
 import fs from 'fs/promises'
 import os from 'os'
 import path from 'path'
-import { predicateFromInputs } from '../src/predicate'
+import { predicateFromInputs, PredicateInputs } from '../src/predicate'
 
 describe('subjectFromInputs', () => {
-  afterEach(() => {
-    process.env['INPUT_PREDICATE'] = ''
-    process.env['INPUT_PREDICATE-PATH'] = ''
-    process.env['INPUT_PREDICATE-TYPE'] = ''
-  })
+  const blankInputs: PredicateInputs = {
+    predicateType: '',
+    predicate: '',
+    predicatePath: ''
+  }
 
   describe('when no inputs are provided', () => {
     it('throws an error', () => {
-      expect(() => predicateFromInputs()).toThrow(/predicate-type/i)
+      expect(() => predicateFromInputs(blankInputs)).toThrow(/predicate-type/i)
     })
   })
 
   describe('when neither predicate path nor predicate are provided', () => {
-    beforeEach(() => {
-      process.env['INPUT_PREDICATE-TYPE'] = 'https://example.com/predicate'
-    })
-
     it('throws an error', () => {
-      expect(() => predicateFromInputs()).toThrow(
+      const inputs: PredicateInputs = {
+        ...blankInputs,
+        predicateType: 'https://example.com/predicate'
+      }
+
+      expect(() => predicateFromInputs(inputs)).toThrow(
         /one of predicate-path or predicate must be provided/i
       )
     })
   })
 
   describe('when both predicate path and predicate are provided', () => {
-    beforeEach(() => {
-      process.env['INPUT_PREDICATE-PATH'] = 'path/to/predicate'
-      process.env['INPUT_PREDICATE'] = '{}'
-      process.env['INPUT_PREDICATE-TYPE'] = 'https://example.com/predicate'
-    })
-
     it('throws an error', () => {
-      expect(() => predicateFromInputs()).toThrow(
+      const inputs: PredicateInputs = {
+        predicateType: 'https://example.com/predicate',
+        predicate: '{}',
+        predicatePath: 'path/to/predicate'
+      }
+
+      expect(() => predicateFromInputs(inputs)).toThrow(
         /only one of predicate-path or predicate may be provided/i
       )
     })
   })
 
   describe('when specifying a predicate path', () => {
-    let dir = ''
-    const filename = 'subject'
+    const predicateType = 'https://example.com/predicate'
     const content = '{}'
+    let predicatePath = ''
 
     beforeEach(async () => {
       // Set-up temp directory
       const tmpDir = await fs.realpath(os.tmpdir())
-      dir = await fs.mkdtemp(tmpDir + path.sep)
+      const dir = await fs.mkdtemp(tmpDir + path.sep)
+
+      const filename = 'subject'
+      predicatePath = path.join(dir, filename)
 
       // Write file to temp directory
-      await fs.writeFile(path.join(dir, filename), content)
+      await fs.writeFile(predicatePath, content)
     })
 
     afterEach(async () => {
       // Clean-up temp directory
-      await fs.rm(dir, { recursive: true })
-    })
-
-    beforeEach(() => {
-      process.env['INPUT_PREDICATE-PATH'] = path.join(dir, filename)
-      process.env['INPUT_PREDICATE-TYPE'] = 'https://example.com/predicate'
+      await fs.rm(path.parse(predicatePath).dir, { recursive: true })
     })
 
     it('returns the predicate', () => {
-      expect(predicateFromInputs()).toEqual({
-        type: 'https://example.com/predicate',
-        params: {}
+      const inputs: PredicateInputs = {
+        ...blankInputs,
+        predicateType,
+        predicatePath
+      }
+      expect(predicateFromInputs(inputs)).toEqual({
+        type: predicateType,
+        params: JSON.parse(content)
       })
     })
   })
 
   describe('when specifying a predicate value', () => {
+    const predicateType = 'https://example.com/predicate'
     const content = '{}'
 
-    beforeEach(() => {
-      process.env['INPUT_PREDICATE'] = content
-      process.env['INPUT_PREDICATE-TYPE'] = 'https://example.com/predicate'
-    })
-
     it('returns the predicate', () => {
-      expect(predicateFromInputs()).toEqual({
-        type: 'https://example.com/predicate',
-        params: {}
+      const inputs: PredicateInputs = {
+        ...blankInputs,
+        predicateType,
+        predicate: content
+      }
+
+      expect(predicateFromInputs(inputs)).toEqual({
+        type: predicateType,
+        params: JSON.parse(content)
       })
     })
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,27 @@
 /**
  * The entrypoint for the action.
  */
-import { run } from './main'
+import * as core from '@actions/core'
+import { run, RunInputs } from './main'
+
+const DEFAULT_BATCH_SIZE = 50
+const DEFAULT_BATCH_DELAY = 5000
+
+const inputs: RunInputs = {
+  subjectPath: core.getInput('subject-path'),
+  subjectName: core.getInput('subject-name'),
+  subjectDigest: core.getInput('subject-digest'),
+  predicateType: core.getInput('predicate-type'),
+  predicate: core.getInput('predicate'),
+  predicatePath: core.getInput('predicate-path'),
+  pushToRegistry: core.getBooleanInput('push-to-registry'),
+  githubToken: core.getInput('github-token'),
+  // undocumented -- not part of public interface
+  privateSigning: core.getBooleanInput('private-signing'),
+  // internal only
+  batchSize: DEFAULT_BATCH_SIZE,
+  batchDelay: DEFAULT_BATCH_DELAY
+}
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
-run()
+run(inputs)

--- a/src/predicate.ts
+++ b/src/predicate.ts
@@ -1,26 +1,32 @@
-import * as core from '@actions/core'
 import fs from 'fs'
 
 import type { Predicate } from '@actions/attest'
 
+export type PredicateInputs = {
+  predicateType: string
+  predicate: string
+  predicatePath: string
+}
 // Returns the predicate specified by the action's inputs. The predicate value
 // may be specified as a path to a file or as a string.
-export const predicateFromInputs = (): Predicate => {
-  const predicateType = core.getInput('predicate-type', { required: true })
-  const predicateStr = core.getInput('predicate', { required: false })
-  const predicatePath = core.getInput('predicate-path', { required: false })
+export const predicateFromInputs = (inputs: PredicateInputs): Predicate => {
+  const { predicateType, predicate, predicatePath } = inputs
 
-  if (!predicatePath && !predicateStr) {
+  if (!predicateType) {
+    throw new Error('predicate-type must be provided')
+  }
+
+  if (!predicatePath && !predicate) {
     throw new Error('One of predicate-path or predicate must be provided')
   }
 
-  if (predicatePath && predicateStr) {
+  if (predicatePath && predicate) {
     throw new Error('Only one of predicate-path or predicate may be provided')
   }
 
   const params = predicatePath
     ? fs.readFileSync(predicatePath, 'utf-8')
-    : predicateStr
+    : predicate
 
   return { type: predicateType, params: JSON.parse(params) }
 }

--- a/src/subject.ts
+++ b/src/subject.ts
@@ -1,4 +1,3 @@
-import * as core from '@actions/core'
 import * as glob from '@actions/glob'
 import crypto from 'crypto'
 import { parse } from 'csv-parse/sync'
@@ -9,17 +8,20 @@ import type { Subject } from '@actions/attest'
 
 const DIGEST_ALGORITHM = 'sha256'
 
+export type SubjectInputs = {
+  subjectPath: string
+  subjectName: string
+  subjectDigest: string
+  downcaseName?: boolean
+}
 // Returns the subject specified by the action's inputs. The subject may be
 // specified as a path to a file or as a digest. If a path is provided, the
 // file's digest is calculated and returned along with the subject's name. If a
 // digest is provided, the name must also be provided.
-export const subjectFromInputs = async (): Promise<Subject[]> => {
-  const subjectPath = core.getInput('subject-path', { required: false })
-  const subjectDigest = core.getInput('subject-digest', { required: false })
-  const subjectName = core.getInput('subject-name', { required: false })
-  const pushToRegistry = core.getBooleanInput('push-to-registry', {
-    required: false
-  })
+export const subjectFromInputs = async (
+  inputs: SubjectInputs
+): Promise<Subject[]> => {
+  const { subjectPath, subjectDigest, subjectName, downcaseName } = inputs
 
   if (!subjectPath && !subjectDigest) {
     throw new Error('One of subject-path or subject-digest must be provided')
@@ -37,7 +39,7 @@ export const subjectFromInputs = async (): Promise<Subject[]> => {
 
   // If push-to-registry is enabled, ensure the subject name is lowercase
   // to conform to OCI image naming conventions
-  const name = pushToRegistry ? subjectName.toLowerCase() : subjectName
+  const name = downcaseName ? subjectName.toLowerCase() : subjectName
 
   if (subjectPath) {
     return await getSubjectFromPath(subjectPath, name)


### PR DESCRIPTION
Internal refactor which centralizes all of the action input collection at the start of the action (as opposed to having `core.getInput()` calls littered throughout the code base). 