### PR TITLE
refactor core attestation logic

### DIFF
--- a/__tests__/style.test.ts
+++ b/__tests__/style.test.ts
@@ -1,0 +1,15 @@
+import { highlight, mute } from '../src/style'
+
+describe('style', () => {
+  describe('highlight', () => {
+    it('adds cyan color to the string', () => {
+      expect(highlight('foo')).toBe('\x1B[36mfoo\x1B[39m')
+    })
+  })
+
+  describe('mute', () => {
+    it('adds gray color to the string', () => {
+      expect(mute('foo')).toBe('\x1B[38;5;244mfoo\x1B[39m')
+    })
+  })
+})

--- a/src/attest.ts
+++ b/src/attest.ts
@@ -1,0 +1,67 @@
+import { Attestation, Predicate, Subject, attest } from '@actions/attest'
+import { attachArtifactToImage, getRegistryCredentials } from '@sigstore/oci'
+
+const OCI_TIMEOUT = 2000
+const OCI_RETRY = 3
+
+export type SigstoreInstance = 'public-good' | 'github'
+export type AttestResult = Attestation & {
+  subjectName: string
+  subjectDigest: string
+  attestationDigest?: string
+}
+
+export const createAttestation = async (
+  subject: Subject,
+  predicate: Predicate,
+  opts: {
+    sigstoreInstance: SigstoreInstance
+    pushToRegistry: boolean
+    githubToken: string
+  }
+): Promise<AttestResult> => {
+  // Sign provenance w/ Sigstore
+  const attestation = await attest({
+    subjectName: subject.name,
+    subjectDigest: subject.digest,
+    predicateType: predicate.type,
+    predicate: predicate.params,
+    sigstore: opts.sigstoreInstance,
+    token: opts.githubToken
+  })
+
+  const subDigest = subjectDigest(subject)
+  const result: AttestResult = {
+    ...attestation,
+    subjectName: subject.name,
+    subjectDigest: subDigest
+  }
+
+  if (opts.pushToRegistry) {
+    const credentials = getRegistryCredentials(subject.name)
+    const artifact = await attachArtifactToImage({
+      credentials,
+      imageName: subject.name,
+      imageDigest: subDigest,
+      artifact: Buffer.from(JSON.stringify(attestation.bundle)),
+      mediaType: attestation.bundle.mediaType,
+      annotations: {
+        'dev.sigstore.bundle.content': 'dsse-envelope',
+        'dev.sigstore.bundle.predicateType': predicate.type
+      },
+      fetchOpts: { timeout: OCI_TIMEOUT, retry: OCI_RETRY }
+    })
+
+    // Add the attestation's digest to the result
+    result.attestationDigest = artifact.digest
+  }
+
+  return result
+}
+
+// Returns the subject's digest as a formatted string of the form
+// "<algorithm>:<digest>".
+const subjectDigest = (subject: Subject): string => {
+  const alg = Object.keys(subject.digest).sort()[0]
+  return `${alg}:${subject.digest[alg]}`
+}

--- a/src/style.ts
+++ b/src/style.ts
@@ -1,0 +1,11 @@
+const COLOR_CYAN = '\x1B[36m'
+const COLOR_GRAY = '\x1B[38;5;244m'
+const COLOR_DEFAULT = '\x1B[39m'
+
+// Emphasis string using ANSI color codes
+export const highlight = (str: string): string =>
+  `${COLOR_CYAN}${str}${COLOR_DEFAULT}`
+
+// De-emphasize string using ANSI color codes
+export const mute = (str: string): string =>
+  `${COLOR_GRAY}${str}${COLOR_DEFAULT}`


### PR DESCRIPTION
Internal refactor of attestation logic to decouple the signing workflow from the logging of output to the GitHub Actions run.