### PR TITLE
fix bug w/ private-signing input

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -80013,7 +80013,7 @@ const inputs = {
     pushToRegistry: core.getBooleanInput('push-to-registry'),
     githubToken: core.getInput('github-token'),
     // undocumented -- not part of public interface
-    privateSigning: core.getBooleanInput('private-signing'),
+    privateSigning: ['true', 'True', 'TRUE', '1'].includes(core.getInput('private-signing')),
     // internal only
     batchSize: DEFAULT_BATCH_SIZE,
     batchDelay: DEFAULT_BATCH_DELAY

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,9 @@ const inputs: RunInputs = {
   pushToRegistry: core.getBooleanInput('push-to-registry'),
   githubToken: core.getInput('github-token'),
   // undocumented -- not part of public interface
-  privateSigning: core.getBooleanInput('private-signing'),
+  privateSigning: ['true', 'True', 'TRUE', '1'].includes(
+    core.getInput('private-signing')
+  ),
   // internal only
   batchSize: DEFAULT_BATCH_SIZE,
   batchDelay: DEFAULT_BATCH_DELAY


### PR DESCRIPTION
Fix bug related to the reading of the `private-signing` input variable.

Since this variable is not officially part of the action interface (undocumented), we can't provide a default value for it. The `getBooleanInput` expects the variable to contain a valid boolean value and will throw an error if one is not found. To properly handle the case of an empty input here (`""`) we need to use the `getInput` helper instead and do our own check for boolean values.