### PR TITLE
batch processing w/ exponential backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ See [action.yml](action.yml)
   with:
     # Path to the artifact serving as the subject of the attestation. Must
     # specify exactly one of "subject-path" or "subject-digest". May contain
-    # a glob pattern or list of paths (total subject count cannot exceed 64).
+    # a glob pattern or list of paths (total subject count cannot exceed 2500).
     subject-path:
 
     # SHA256 digest of the subject for the attestation. Must be in the form
@@ -114,6 +114,15 @@ Attestations are saved in the JSON-serialized [Sigstore bundle][6] format.
 If multiple subjects are being attested at the same time, each attestation will
 be written to the output file on a separate line (using the [JSON Lines][7]
 format).
+
+## Attestation Limits
+
+### Subject Limits
+
+No more than 2500 subjects can be attested at the same time. Subjects will be
+processed in batches 50. After the initial group of 50, each subsequent batch
+will incur an exponentially increasing amount of delay (capped at 1 minute of
+delay per batch) to avoid overwhelming the attestation API.
 
 ## Examples
 
@@ -175,8 +184,8 @@ fully-qualified image name (e.g. "ghcr.io/user/app" or
 "acme.azurecr.io/user/app"). Do NOT include a tag as part of the image name --
 the specific image being attested is identified by the supplied digest.
 
-> **NOTE**: When pushing to Docker Hub, please use "docker.io" as the
-> registry portion of the image name.
+> **NOTE**: When pushing to Docker Hub, please use "docker.io" as the registry
+> portion of the image name.
 
 ```yaml
 name: build-attested-image

--- a/__tests__/subject.test.ts
+++ b/__tests__/subject.test.ts
@@ -151,7 +151,7 @@ describe('subjectFromInputs', () => {
     })
   })
 
-  describe('when the file eixts', () => {
+  describe('when the file exists', () => {
     let dir = ''
     const filename = 'subject'
     const content = 'file content'

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: >
       Path to the artifact serving as the subject of the attestation. Must
       specify exactly one of "subject-path" or "subject-digest". May contain a
-      glob pattern or list of paths (total subject count cannot exceed 64).
+      glob pattern or list of paths (total subject count cannot exceed 2500).
     required: false
   subject-digest:
     description: >

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ import * as core from '@actions/core'
 import { run, RunInputs } from './main'
 
 const DEFAULT_BATCH_SIZE = 50
-const DEFAULT_BATCH_DELAY = 5000
 
 const inputs: RunInputs = {
   subjectPath: core.getInput('subject-path'),
@@ -21,8 +20,7 @@ const inputs: RunInputs = {
     core.getInput('private-signing')
   ),
   // internal only
-  batchSize: DEFAULT_BATCH_SIZE,
-  batchDelay: DEFAULT_BATCH_DELAY
+  batchSize: DEFAULT_BATCH_SIZE
 }
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises


### PR DESCRIPTION
Introduces a new hard limit of 2500 subjects which can be attested with a single invocation of the action.

Subjects are processed in batches of 50 with an exponential delay added after the initial batch is processed:
* Batch 2: 7.5 seconds (150ms per attestation)
* Batch 3: 15 seconds (300ms per attestation)
* Batch 4: 30 seconds (600ms per attestation)
* Batches 5-50: 60 seconds (1200ms per attestation)