### PR TITLE
bump @sigstore/oci to 0.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "actions/attest",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "actions/attest",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@actions/attest": "^1.2.1",
         "@actions/core": "^1.10.1",
         "@actions/glob": "^0.4.0",
-        "@sigstore/oci": "^0.3.4",
+        "@sigstore/oci": "^0.3.6",
         "csv-parse": "^5.5.6"
       },
       "devDependencies": {
@@ -1729,9 +1729,9 @@
       }
     },
     "node_modules/@sigstore/oci": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@sigstore/oci/-/oci-0.3.4.tgz",
-      "integrity": "sha512-ydRTsvHOmLWnlR2BTtG1pHYvLkHG/oaqVyd2WDkfLU7B3dIWfqavE80VCzidNWuZpXN7m8+uBNatus2Qva1ktA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@sigstore/oci/-/oci-0.3.6.tgz",
+      "integrity": "sha512-nv/uHEHj6AbzGcBg1Cs7EsetB0M+N8GW1wYA26KQT6ymirv5UWUtqx9L1hbJjClpQ6/8R0vYXCpunvic2O1jfg==",
       "dependencies": {
         "make-fetch-happen": "^13.0.1",
         "proc-log": "^4.2.0"
@@ -9834,9 +9834,9 @@
       }
     },
     "@sigstore/oci": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@sigstore/oci/-/oci-0.3.4.tgz",
-      "integrity": "sha512-ydRTsvHOmLWnlR2BTtG1pHYvLkHG/oaqVyd2WDkfLU7B3dIWfqavE80VCzidNWuZpXN7m8+uBNatus2Qva1ktA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@sigstore/oci/-/oci-0.3.6.tgz",
+      "integrity": "sha512-nv/uHEHj6AbzGcBg1Cs7EsetB0M+N8GW1wYA26KQT6ymirv5UWUtqx9L1hbJjClpQ6/8R0vYXCpunvic2O1jfg==",
       "requires": {
         "make-fetch-happen": "^13.0.1",
         "proc-log": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "actions/attest",
   "description": "Generate signed attestations for workflow artifacts",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "",
   "private": true,
   "homepage": "https://github.com/actions/attest",
@@ -72,7 +72,7 @@
     "@actions/attest": "^1.2.1",
     "@actions/core": "^1.10.1",
     "@actions/glob": "^0.4.0",
-    "@sigstore/oci": "^0.3.4",
+    "@sigstore/oci": "^0.3.6",
     "csv-parse": "^5.5.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Bump `@sigstore/oci` from 0.3.4 to 0.3.6.

Includes bug fix for issue when pushing attestations into AWS ECR registries.