### PR TITLE
Bump @actions/attest from 1.2.1 to 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "actions/attest",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "actions/attest",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
-        "@actions/attest": "^1.2.1",
+        "@actions/attest": "^1.3.0",
         "@actions/core": "^1.10.1",
         "@actions/glob": "^0.4.0",
         "@sigstore/oci": "^0.3.6",
@@ -51,16 +51,16 @@
       }
     },
     "node_modules/@actions/attest": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@actions/attest/-/attest-1.2.1.tgz",
-      "integrity": "sha512-ZLfmO6o2x3UL2BG++oIHMPx5kApWr8Uy1cgiiafXpHgamsqFUPjUtcp0/gpOaXkxUZftdVno7NwBTisw8qr9UA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@actions/attest/-/attest-1.3.0.tgz",
+      "integrity": "sha512-Xmv+HIefU8PMx3q+BwGmL28MLyQ2FF05ROZjH+iuoQ9q43qzmbJmmzou3NBOSspUa1N2nVtirPq7jPj9g8AMEg==",
       "dependencies": {
         "@actions/core": "^1.10.1",
         "@actions/github": "^6.0.0",
         "@actions/http-client": "^2.2.1",
         "@octokit/plugin-retry": "^6.0.1",
-        "@sigstore/bundle": "^2.3.0",
-        "@sigstore/sign": "^2.3.0",
+        "@sigstore/bundle": "^2.3.2",
+        "@sigstore/sign": "^2.3.2",
         "jsonwebtoken": "^9.0.2",
         "jwks-rsa": "^3.1.0"
       }
@@ -1689,11 +1689,11 @@
       }
     },
     "node_modules/@sigstore/bundle": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.3.1.tgz",
-      "integrity": "sha512-eqV17lO3EIFqCWK3969Rz+J8MYrRZKw9IBHpSo6DEcEX2c+uzDFOgHE9f2MnyDpfs48LFO4hXmk9KhQ74JzU1g==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.3.2.tgz",
+      "integrity": "sha512-wueKWDk70QixNLB363yHc2D2ItTgYiMTdPwK8D9dKQMR3ZQ0c35IxP5xnwQ8cNLoCgCRcHf14kE+CLIvNX1zmA==",
       "dependencies": {
-        "@sigstore/protobuf-specs": "^0.3.1"
+        "@sigstore/protobuf-specs": "^0.3.2"
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
@@ -1749,13 +1749,13 @@
       }
     },
     "node_modules/@sigstore/sign": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.3.1.tgz",
-      "integrity": "sha512-YZ71wKIOweC8ViUeZXboz0iPLqMkskxuoeN/D1CEpAyZvEepbX9oRMIoO6a/DxUqO1VEaqmcmmqzSiqtOsvSmw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.3.2.tgz",
+      "integrity": "sha512-5Vz5dPVuunIIvC5vBb0APwo7qKA4G9yM48kPWJT+OEERs40md5GoUR1yedwpekWZ4m0Hhw44m6zU+ObsON+iDA==",
       "dependencies": {
-        "@sigstore/bundle": "^2.3.0",
+        "@sigstore/bundle": "^2.3.2",
         "@sigstore/core": "^1.0.0",
-        "@sigstore/protobuf-specs": "^0.3.1",
+        "@sigstore/protobuf-specs": "^0.3.2",
         "make-fetch-happen": "^13.0.1",
         "proc-log": "^4.2.0",
         "promise-retry": "^2.0.1"
@@ -8666,16 +8666,16 @@
       "dev": true
     },
     "@actions/attest": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@actions/attest/-/attest-1.2.1.tgz",
-      "integrity": "sha512-ZLfmO6o2x3UL2BG++oIHMPx5kApWr8Uy1cgiiafXpHgamsqFUPjUtcp0/gpOaXkxUZftdVno7NwBTisw8qr9UA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@actions/attest/-/attest-1.3.0.tgz",
+      "integrity": "sha512-Xmv+HIefU8PMx3q+BwGmL28MLyQ2FF05ROZjH+iuoQ9q43qzmbJmmzou3NBOSspUa1N2nVtirPq7jPj9g8AMEg==",
       "requires": {
         "@actions/core": "^1.10.1",
         "@actions/github": "^6.0.0",
         "@actions/http-client": "^2.2.1",
         "@octokit/plugin-retry": "^6.0.1",
-        "@sigstore/bundle": "^2.3.0",
-        "@sigstore/sign": "^2.3.0",
+        "@sigstore/bundle": "^2.3.2",
+        "@sigstore/sign": "^2.3.2",
         "jsonwebtoken": "^9.0.2",
         "jwks-rsa": "^3.1.0"
       }
@@ -9807,11 +9807,11 @@
       "dev": true
     },
     "@sigstore/bundle": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.3.1.tgz",
-      "integrity": "sha512-eqV17lO3EIFqCWK3969Rz+J8MYrRZKw9IBHpSo6DEcEX2c+uzDFOgHE9f2MnyDpfs48LFO4hXmk9KhQ74JzU1g==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.3.2.tgz",
+      "integrity": "sha512-wueKWDk70QixNLB363yHc2D2ItTgYiMTdPwK8D9dKQMR3ZQ0c35IxP5xnwQ8cNLoCgCRcHf14kE+CLIvNX1zmA==",
       "requires": {
-        "@sigstore/protobuf-specs": "^0.3.1"
+        "@sigstore/protobuf-specs": "^0.3.2"
       }
     },
     "@sigstore/core": {
@@ -9852,13 +9852,13 @@
       "integrity": "sha512-c6B0ehIWxMI8wiS/bj6rHMPqeFvngFV7cDU/MY+B16P9Z3Mp9k8L93eYZ7BYzSickzuqAQqAq0V956b3Ju6mLw=="
     },
     "@sigstore/sign": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.3.1.tgz",
-      "integrity": "sha512-YZ71wKIOweC8ViUeZXboz0iPLqMkskxuoeN/D1CEpAyZvEepbX9oRMIoO6a/DxUqO1VEaqmcmmqzSiqtOsvSmw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-2.3.2.tgz",
+      "integrity": "sha512-5Vz5dPVuunIIvC5vBb0APwo7qKA4G9yM48kPWJT+OEERs40md5GoUR1yedwpekWZ4m0Hhw44m6zU+ObsON+iDA==",
       "requires": {
-        "@sigstore/bundle": "^2.3.0",
+        "@sigstore/bundle": "^2.3.2",
         "@sigstore/core": "^1.0.0",
-        "@sigstore/protobuf-specs": "^0.3.1",
+        "@sigstore/protobuf-specs": "^0.3.2",
         "make-fetch-happen": "^13.0.1",
         "proc-log": "^4.2.0",
         "promise-retry": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "actions/attest",
   "description": "Generate signed attestations for workflow artifacts",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "author": "",
   "private": true,
   "homepage": "https://github.com/actions/attest",
@@ -69,7 +69,7 @@
     ]
   },
   "dependencies": {
-    "@actions/attest": "^1.2.1",
+    "@actions/attest": "^1.3.0",
     "@actions/core": "^1.10.1",
     "@actions/glob": "^0.4.0",
     "@sigstore/oci": "^0.3.6",


### PR DESCRIPTION
Bump the `@actions/attest` library from 1.2.1 to 1.3.0

Includes the following changes:
* Dynamic construction of GitHub API URLs based on GITHUB_SERVER_URL
* Improved handling of Rekor 409 responses