### PR TITLE
bump @sigstore/oci from 0.3.6 to 0.3.7

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11758,7 +11758,7 @@ class OCIImage {
             // the referrers API but still reports a subjectDigest).
             const referrersSupported = await __classPrivateFieldGet(this, _OCIImage_client, "f").pingReferrers();
             // Manually update the referrers list if the referrers API is not supported.
-            if (!referrersSupported) {
+            if (!artifactDescriptor.subjectDigest || !referrersSupported) {
                 // Strip subjectDigest from the artifact descriptor (in case it was returned)
                 /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
                 const { subjectDigest, ...descriptor } = artifactDescriptor;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "actions/attest",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "actions/attest",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@actions/attest": "^1.3.0",
         "@actions/core": "^1.10.1",
         "@actions/glob": "^0.4.0",
-        "@sigstore/oci": "^0.3.6",
+        "@sigstore/oci": "^0.3.7",
         "csv-parse": "^5.5.6"
       },
       "devDependencies": {
@@ -1729,9 +1729,9 @@
       }
     },
     "node_modules/@sigstore/oci": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@sigstore/oci/-/oci-0.3.6.tgz",
-      "integrity": "sha512-nv/uHEHj6AbzGcBg1Cs7EsetB0M+N8GW1wYA26KQT6ymirv5UWUtqx9L1hbJjClpQ6/8R0vYXCpunvic2O1jfg==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@sigstore/oci/-/oci-0.3.7.tgz",
+      "integrity": "sha512-1JmebwEXil+NVzugFURbC+D3Vzj6WyTI1B+7damUk94dWXamE9cJ057iSo72rupiSozM6N7lVMjtD1c/P5Rrrw==",
       "dependencies": {
         "make-fetch-happen": "^13.0.1",
         "proc-log": "^4.2.0"
@@ -9838,9 +9838,9 @@
       }
     },
     "@sigstore/oci": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@sigstore/oci/-/oci-0.3.6.tgz",
-      "integrity": "sha512-nv/uHEHj6AbzGcBg1Cs7EsetB0M+N8GW1wYA26KQT6ymirv5UWUtqx9L1hbJjClpQ6/8R0vYXCpunvic2O1jfg==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@sigstore/oci/-/oci-0.3.7.tgz",
+      "integrity": "sha512-1JmebwEXil+NVzugFURbC+D3Vzj6WyTI1B+7damUk94dWXamE9cJ057iSo72rupiSozM6N7lVMjtD1c/P5Rrrw==",
       "requires": {
         "make-fetch-happen": "^13.0.1",
         "proc-log": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "actions/attest",
   "description": "Generate signed attestations for workflow artifacts",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": "",
   "private": true,
   "homepage": "https://github.com/actions/attest",
@@ -72,7 +72,7 @@
     "@actions/attest": "^1.3.0",
     "@actions/core": "^1.10.1",
     "@actions/glob": "^0.4.0",
-    "@sigstore/oci": "^0.3.6",
+    "@sigstore/oci": "^0.3.7",
     "csv-parse": "^5.5.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Bump `@sigstore/oci` from 0.3.6 to 0.3.7.

Includes bugfix for issue when detecting support for the referrers API with OCI registries