### PR TITLE
add multi-subject example to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ jobs:
           predicate: '{}'
 ```
 
-### Identify Subjects by Wildcard
+### Identify Multiple Subjects
 
 If you are generating multiple artifacts, you can generate an attestation for
 each by using a wildcard in the `subject-path` input.
@@ -179,6 +179,23 @@ each by using a wildcard in the `subject-path` input.
 
 For supported wildcards along with behavior and documentation, see
 [@actions/glob][8] which is used internally to search for files.
+
+Alternatively, you can explicitly list multiple subjects with either a comma or
+newline delimited list:
+
+```yaml
+- uses: actions/attest-build-provenance@v1
+  with:
+    subject-path: 'dist/foo, dist/bar'
+```
+
+```yaml
+- uses: actions/attest-build-provenance@v1
+  with:
+    subject-path: |
+      dist/foo
+      dist/bar
+```
 
 ### Container Image
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Alternatively, you can explicitly list multiple subjects with either a comma or
 newline delimited list:
 
 ```yaml
-- uses: actions/attest-build-provenance@v1
+- uses: actions/attest@v1
   with:
     subject-path: 'dist/foo, dist/bar'
 ```

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ newline delimited list:
 ```
 
 ```yaml
-- uses: actions/attest-build-provenance@v1
+- uses: actions/attest@v1
   with:
     subject-path: |
       dist/foo


### PR DESCRIPTION
Update README with examples of using comma/newline delimited lists to identify multiple attestation subjects.