### PR TITLE
bugfix for glob exclude patterns

### DIFF
--- a/__tests__/subject.test.ts
+++ b/__tests__/subject.test.ts
@@ -296,6 +296,29 @@ describe('subjectFromInputs', () => {
       })
     })
 
+    describe('when an excluding glob is supplied', () => {
+      it('returns the multiple subjects', async () => {
+        const inputs: SubjectInputs = {
+          ...blankInputs,
+          subjectPath: `${path.join(dir, 'subject-*')},!${path.join(dir, 'subject-1')}`
+        }
+
+        const subjects = await subjectFromInputs(inputs)
+
+        expect(subjects).toBeDefined()
+        expect(subjects).toHaveLength(2)
+
+        expect(subjects).toContainEqual({
+          name: 'subject-0',
+          digest: { sha256: expectedDigest }
+        })
+        expect(subjects).toContainEqual({
+          name: 'subject-2',
+          digest: { sha256: expectedDigest }
+        })
+      })
+    })
+
     describe('when a multi-line glob list is supplied', () => {
       it('returns the multiple subjects', async () => {
         const inputs: SubjectInputs = {

--- a/dist/index.js
+++ b/dist/index.js
@@ -80356,14 +80356,11 @@ exports.subjectFromInputs = subjectFromInputs;
 // calculated and returned along with the subject's name.
 const getSubjectFromPath = async (subjectPath, subjectName) => {
     const digestedSubjects = [];
-    const files = [];
     // Parse the list of subject paths
-    const subjectPaths = parseList(subjectPath);
+    const subjectPaths = parseList(subjectPath).join('\n');
     // Expand the globbed paths to a list of files
-    for (const subPath of subjectPaths) {
-        /* eslint-disable-next-line github/no-then */
-        files.push(...(await glob.create(subPath).then(async (g) => g.glob())));
-    }
+    /* eslint-disable-next-line github/no-then */
+    const files = await glob.create(subjectPaths).then(async (g) => g.glob());
     if (files.length > MAX_SUBJECT_COUNT) {
         throw new Error(`Too many subjects specified. The maximum number of subjects is ${MAX_SUBJECT_COUNT}.`);
     }

--- a/src/subject.ts
+++ b/src/subject.ts
@@ -56,16 +56,13 @@ const getSubjectFromPath = async (
   subjectName?: string
 ): Promise<Subject[]> => {
   const digestedSubjects: Subject[] = []
-  const files: string[] = []
 
   // Parse the list of subject paths
-  const subjectPaths = parseList(subjectPath)
+  const subjectPaths = parseList(subjectPath).join('\n')
 
   // Expand the globbed paths to a list of files
-  for (const subPath of subjectPaths) {
-    /* eslint-disable-next-line github/no-then */
-    files.push(...(await glob.create(subPath).then(async g => g.glob())))
-  }
+  /* eslint-disable-next-line github/no-then */
+  const files = await glob.create(subjectPaths).then(async g => g.glob())
 
   if (files.length > MAX_SUBJECT_COUNT) {
     throw new Error(


### PR DESCRIPTION
Per: https://github.com/actions/attest-build-provenance/issues/150

Fixes a bug with the way that glob patterns for the subject path are handled. Previously, each glob pattern was processed separately, which caused issues when an exclusion (`!`) pattern was supplied.

This change passes all of the glob patterns to the glob library at once, which ensures that exclusion patterns are handled correctly.
