### PR TITLE
bump package version to 1.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actions/attest",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "actions/attest",
-      "version": "1.3.1",
+      "version": "1.3.3",
       "license": "MIT",
       "dependencies": {
         "@actions/attest": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "actions/attest",
   "description": "Generate signed attestations for workflow artifacts",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "author": "",
   "private": true,
   "homepage": "https://github.com/actions/attest",


### PR DESCRIPTION
Updates the package version to 1.3.3 in the `package.json` file.

Note, the we missed the 1.3.2 version bump, so we are going straight to 1.3.3.