### PR TITLE
format summary output as list

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -80189,11 +80189,13 @@ const logSummary = (attestations) => {
         core.summary.addHeading(
         /* istanbul ignore next */
         attestations.length > 1 ? 'Attestations Created' : 'Attestation Created', 3);
+        const listItems = [];
         for (const { subjectName, subjectDigest, attestationID } of attestations) {
             if (attestationID) {
-                core.summary.addLink(`${subjectName}@${subjectDigest}`, attestationURL(attestationID));
+                listItems.push(`<a href="${attestationURL(attestationID)}">${subjectName}@${subjectDigest}</a>`);
             }
         }
+        core.summary.addList(listItems);
         core.summary.write();
     }
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -166,14 +166,16 @@ const logSummary = (attestations: AttestResult[]): void => {
       3
     )
 
+    const listItems = []
     for (const { subjectName, subjectDigest, attestationID } of attestations) {
       if (attestationID) {
-        core.summary.addLink(
-          `${subjectName}@${subjectDigest}`,
-          attestationURL(attestationID)
+        listItems.push(
+          `<a href="${attestationURL(attestationID)}">${subjectName}@${subjectDigest}</a>`
         )
       }
     }
+
+    core.summary.addList(listItems)
     core.summary.write()
   }
 }


### PR DESCRIPTION
Fixes the job summary output when multiple attestations are generated. 

Previously, there was no structure to the emitted links. Now, the links are added to an unordered list.

Before:

<img width="846" alt="image" src="https://github.com/user-attachments/assets/6fbef6c2-a5c7-42ca-861d-8917da444591">

After:

<img width="838" alt="image" src="https://github.com/user-attachments/assets/bc886e86-7f20-4ee7-9dcd-50b38ce674e6">

Fixes: https://github.com/actions/attest-build-provenance/issues/155