### PR TITLE
add show-summary input

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ See [action.yml](action.yml)
     # the "subject-digest" parameter be specified. Defaults to false.
     push-to-registry:
 
+    # Whether to attach a list of generated attestations to the workflow run
+    # summary page. Defaults to true.
+    show-summary:
+
     # The GitHub token used to make authenticated API requests. Default is
     # ${{ github.token }}
     github-token:

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -44,6 +44,7 @@ const defaultInputs: main.RunInputs = {
   subjectDigest: '',
   subjectPath: '',
   pushToRegistry: false,
+  showSummary: true,
   githubToken: '',
   privateSigning: false,
   batchSize: 50

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,12 @@ inputs:
       the "subject-digest" parameter be specified. Defaults to false.
     default: false
     required: false
+  show-summary:
+    description: >
+      Whether to attach a list of generated attestations to the workflow run
+      summary page. Defaults to true.
+    default: true
+    required: false
   github-token:
     description: >
       The GitHub token used to make authenticated API requests.

--- a/dist/index.js
+++ b/dist/index.js
@@ -80030,6 +80030,7 @@ const inputs = {
     predicate: core.getInput('predicate'),
     predicatePath: core.getInput('predicate-path'),
     pushToRegistry: core.getBooleanInput('push-to-registry'),
+    showSummary: core.getBooleanInput('show-summary'),
     githubToken: core.getInput('github-token'),
     // undocumented -- not part of public interface
     privateSigning: ['true', 'True', 'TRUE', '1'].includes(core.getInput('private-signing')),
@@ -80147,7 +80148,9 @@ async function run(inputs) {
                 });
             }
         }
-        logSummary(atts);
+        if (inputs.showSummary) {
+            logSummary(atts);
+        }
     }
     catch (err) {
         // Fail the workflow run if an error occurs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actions/attest",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "actions/attest",
-      "version": "1.3.3",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@actions/attest": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "actions/attest",
   "description": "Generate signed attestations for workflow artifacts",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "author": "",
   "private": true,
   "homepage": "https://github.com/actions/attest",

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ const inputs: RunInputs = {
   predicate: core.getInput('predicate'),
   predicatePath: core.getInput('predicate-path'),
   pushToRegistry: core.getBooleanInput('push-to-registry'),
+  showSummary: core.getBooleanInput('show-summary'),
   githubToken: core.getInput('github-token'),
   // undocumented -- not part of public interface
   privateSigning: ['true', 'True', 'TRUE', '1'].includes(

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ export type RunInputs = SubjectInputs &
   PredicateInputs & {
     pushToRegistry: boolean
     githubToken: string
+    showSummary: boolean
     privateSigning: boolean
     batchSize: number
   }
@@ -96,7 +97,9 @@ export async function run(inputs: RunInputs): Promise<void> {
       }
     }
 
-    logSummary(atts)
+    if (inputs.showSummary) {
+      logSummary(atts)
+    }
   } catch (err) {
     // Fail the workflow run if an error occurs
     core.setFailed(


### PR DESCRIPTION
Adds a new `show-summary` input argument which can be used to suppress the job summary output.

Per: https://github.com/actions/attest-build-provenance/issues/126