### PR TITLE
support multi-subject attestations

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,18 +117,14 @@ See [action.yml](action.yml)
 
 Attestations are saved in the JSON-serialized [Sigstore bundle][6] format.
 
-If multiple subjects are being attested at the same time, each attestation will
-be written to the output file on a separate line (using the [JSON Lines][7]
-format).
+If multiple subjects are being attested at the same time, a single attestation
+will be created with references to each of the supplied subjects.
 
 ## Attestation Limits
 
 ### Subject Limits
 
-No more than 2500 subjects can be attested at the same time. Subjects will be
-processed in batches 50. After the initial group of 50, each subsequent batch
-will incur an exponentially increasing amount of delay (capped at 1 minute of
-delay per batch) to avoid overwhelming the attestation API.
+No more than 1024 subjects can be attested at the same time.
 
 ### Predicate Limits
 
@@ -269,7 +265,6 @@ jobs:
 [5]: https://cli.github.com/manual/gh_attestation_verify
 [6]:
   https://github.com/sigstore/protobuf-specs/blob/main/protos/sigstore_bundle.proto
-[7]: https://jsonlines.org/
 [8]: https://github.com/actions/toolkit/tree/main/packages/glob#patterns
 [9]:
   https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds

--- a/__tests__/subject.test.ts
+++ b/__tests__/subject.test.ts
@@ -2,7 +2,11 @@ import crypto from 'crypto'
 import fs from 'fs/promises'
 import os from 'os'
 import path from 'path'
-import { subjectFromInputs, SubjectInputs } from '../src/subject'
+import {
+  formatSubjectDigest,
+  subjectFromInputs,
+  SubjectInputs
+} from '../src/subject'
 
 describe('subjectFromInputs', () => {
   const blankInputs: SubjectInputs = {
@@ -358,5 +362,17 @@ describe('subjectFromInputs', () => {
         })
       })
     })
+  })
+})
+
+describe('subjectDigest', () => {
+  it('returns the digest', () => {
+    const subject = {
+      name: 'foo',
+      digest: { sha1: 'deadbeef' }
+    }
+
+    const digest = formatSubjectDigest(subject)
+    expect(digest).toEqual('sha1:deadbeef')
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actions/attest",
-  "version": "1.4.1",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "actions/attest",
-      "version": "1.4.1",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/attest": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "actions/attest",
   "description": "Generate signed attestations for workflow artifacts",
-  "version": "1.4.1",
+  "version": "2.0.0",
   "author": "",
   "private": true,
   "homepage": "https://github.com/actions/attest",

--- a/src/attest.ts
+++ b/src/attest.ts
@@ -1,18 +1,17 @@
 import { Attestation, Predicate, Subject, attest } from '@actions/attest'
 import { attachArtifactToImage, getRegistryCredentials } from '@sigstore/oci'
+import { formatSubjectDigest } from './subject'
 
 const OCI_TIMEOUT = 30000
 const OCI_RETRY = 3
 
 export type SigstoreInstance = 'public-good' | 'github'
 export type AttestResult = Attestation & {
-  subjectName: string
-  subjectDigest: string
   attestationDigest?: string
 }
 
 export const createAttestation = async (
-  subject: Subject,
+  subjects: Subject[],
   predicate: Predicate,
   opts: {
     sigstoreInstance: SigstoreInstance
@@ -22,27 +21,22 @@ export const createAttestation = async (
 ): Promise<AttestResult> => {
   // Sign provenance w/ Sigstore
   const attestation = await attest({
-    subjectName: subject.name,
-    subjectDigest: subject.digest,
+    subjects,
     predicateType: predicate.type,
     predicate: predicate.params,
     sigstore: opts.sigstoreInstance,
     token: opts.githubToken
   })
 
-  const subDigest = subjectDigest(subject)
-  const result: AttestResult = {
-    ...attestation,
-    subjectName: subject.name,
-    subjectDigest: subDigest
-  }
+  const result: AttestResult = attestation
 
-  if (opts.pushToRegistry) {
+  if (subjects.length === 1 && opts.pushToRegistry) {
+    const subject = subjects[0]
     const credentials = getRegistryCredentials(subject.name)
     const artifact = await attachArtifactToImage({
       credentials,
       imageName: subject.name,
-      imageDigest: subDigest,
+      imageDigest: formatSubjectDigest(subject),
       artifact: Buffer.from(JSON.stringify(attestation.bundle)),
       mediaType: attestation.bundle.mediaType,
       annotations: {
@@ -57,11 +51,4 @@ export const createAttestation = async (
   }
 
   return result
-}
-
-// Returns the subject's digest as a formatted string of the form
-// "<algorithm>:<digest>".
-const subjectDigest = (subject: Subject): string => {
-  const alg = Object.keys(subject.digest).sort()[0]
-  return `${alg}:${subject.digest[alg]}`
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,6 @@
 import * as core from '@actions/core'
 import { run, RunInputs } from './main'
 
-const DEFAULT_BATCH_SIZE = 50
-
 const inputs: RunInputs = {
   subjectPath: core.getInput('subject-path'),
   subjectName: core.getInput('subject-name'),
@@ -19,9 +17,7 @@ const inputs: RunInputs = {
   // undocumented -- not part of public interface
   privateSigning: ['true', 'True', 'TRUE', '1'].includes(
     core.getInput('private-signing')
-  ),
-  // internal only
-  batchSize: DEFAULT_BATCH_SIZE
+  )
 }
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises


### PR DESCRIPTION
When attesting multiple subjects at the same time, a single attestation will be created with references to each of the supplied subjects. This replaces the previous behavior which resulted in a separate attestation for each subject.

Also lowers the limit on the number of subjects which can be attested at a time from 2500 to 1024. Attesting more than 1024 subjects will require additional invocations of the action.