### PR TITLE
Deduplicate subjects before adding to statement

### DIFF
--- a/__tests__/subject.test.ts
+++ b/__tests__/subject.test.ts
@@ -362,6 +362,31 @@ describe('subjectFromInputs', () => {
         })
       })
     })
+
+    describe('when duplicate subjects are supplied', () => {
+      let otherDir = ''
+
+      // Add duplicate subject in alternate directory
+      beforeEach(async () => {
+        // Set-up temp directory
+        const tmpDir = await fs.realpath(os.tmpdir())
+        otherDir = await fs.mkdtemp(tmpDir + path.sep)
+
+        // Write file to temp directory
+        await fs.writeFile(path.join(otherDir, filename), content)
+      })
+
+      it('returns de-duplicated subjects', async () => {
+        const inputs: SubjectInputs = {
+          ...blankInputs,
+          subjectPath: `${path.join(dir, 'subject')}, ${path.join(otherDir, 'subject')} `
+        }
+        const subjects = await subjectFromInputs(inputs)
+
+        expect(subjects).toBeDefined()
+        expect(subjects).toHaveLength(1)
+      })
+    })
   })
 })
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -71205,7 +71205,10 @@ const getSubjectFromPath = async (subjectPath, subjectName) => {
     for (const file of files) {
         const name = subjectName || path_1.default.parse(file).base;
         const digest = await digestFile(DIGEST_ALGORITHM, file);
-        digestedSubjects.push({ name, digest: { [DIGEST_ALGORITHM]: digest } });
+        // Only add the subject if it is not already in the list
+        if (!digestedSubjects.some(s => s.name === name && s.digest[DIGEST_ALGORITHM] === digest)) {
+            digestedSubjects.push({ name, digest: { [DIGEST_ALGORITHM]: digest } });
+        }
     }
     if (digestedSubjects.length === 0) {
         throw new Error(`Could not find subject at path ${subjectPath}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actions/attest",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "actions/attest",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@actions/attest": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "actions/attest",
   "description": "Generate signed attestations for workflow artifacts",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "",
   "private": true,
   "homepage": "https://github.com/actions/attest",

--- a/src/subject.ts
+++ b/src/subject.ts
@@ -84,7 +84,14 @@ const getSubjectFromPath = async (
     const name = subjectName || path.parse(file).base
     const digest = await digestFile(DIGEST_ALGORITHM, file)
 
-    digestedSubjects.push({ name, digest: { [DIGEST_ALGORITHM]: digest } })
+    // Only add the subject if it is not already in the list
+    if (
+      !digestedSubjects.some(
+        s => s.name === name && s.digest[DIGEST_ALGORITHM] === digest
+      )
+    ) {
+      digestedSubjects.push({ name, digest: { [DIGEST_ALGORITHM]: digest } })
+    }
   }
 
   if (digestedSubjects.length === 0) {


### PR DESCRIPTION
When attesting multiple subjects at the same time, the action should ensure that each subject (name & digest) are unique.

This change deduplicates the subject list before adding it to the intoto statement.