### PR TITLE
add attestation-id and attestation-url outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ attest:
 1. Add the following to your workflow after your artifact has been built:
 
    ```yaml
-   - uses: actions/attest@v1
+   - uses: actions/attest@v2
      with:
        subject-path: '<PATH TO ARTIFACT>'
        predicate-type: '<PREDICATE URI>'
@@ -61,7 +61,7 @@ attest:
 See [action.yml](action.yml)
 
 ```yaml
-- uses: actions/attest@v1
+- uses: actions/attest@v2
   with:
     # Path to the artifact serving as the subject of the attestation. Must
     # specify exactly one of "subject-path" or "subject-digest". May contain
@@ -109,9 +109,11 @@ See [action.yml](action.yml)
 
 <!-- markdownlint-disable MD013 -->
 
-| Name          | Description                                                    | Example                 |
-| ------------- | -------------------------------------------------------------- | ----------------------- |
-| `bundle-path` | Absolute path to the file containing the generated attestation | `/tmp/attestation.json` |
+| Name              | Description                                                    | Example                                          |
+| ----------------- | -------------------------------------------------------------- | ------------------------------------------------ |
+| `attestation-id`  | GitHub ID for the attestation                                  | `123456`                                         |
+| `attestation-url` | Absolute path to the file containing the generated attestation | `https://github.com/foo/bar/attestations/123456` |
+| `bundle-path`     | Absolute path to the file containing the generated attestation | `/tmp/attestation.json`                          |
 
 <!-- markdownlint-enable MD013 -->
 
@@ -157,7 +159,7 @@ jobs:
       - name: Build artifact
         run: make my-app
       - name: Attest
-        uses: actions/attest@v1
+        uses: actions/attest@v2
         with:
           subject-path: '${{ github.workspace }}/my-app'
           predicate-type: 'https://example.com/predicate/v1'
@@ -170,7 +172,7 @@ If you are generating multiple artifacts, you can attest all of them at the same
 time by using a wildcard in the `subject-path` input.
 
 ```yaml
-- uses: actions/attest@v1
+- uses: actions/attest@v2
   with:
     subject-path: 'dist/**/my-bin-*'
     predicate-type: 'https://example.com/predicate/v1'
@@ -184,13 +186,13 @@ Alternatively, you can explicitly list multiple subjects with either a comma or
 newline delimited list:
 
 ```yaml
-- uses: actions/attest@v1
+- uses: actions/attest@v2
   with:
     subject-path: 'dist/foo, dist/bar'
 ```
 
 ```yaml
-- uses: actions/attest@v1
+- uses: actions/attest@v2
   with:
     subject-path: |
       dist/foo
@@ -247,7 +249,7 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
       - name: Attest
-        uses: actions/attest@v1
+        uses: actions/attest@v2
         id: attest
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -199,6 +199,16 @@ describe('action', () => {
         'bundle-path',
         expect.stringMatching('attestation.json')
       )
+      expect(setOutputMock).toHaveBeenNthCalledWith(
+        2,
+        'attestation-id',
+        expect.stringMatching(attestationID)
+      )
+      expect(setOutputMock).toHaveBeenNthCalledWith(
+        3,
+        'attestation-url',
+        expect.stringContaining(`foo/bar/attestations/${attestationID}`)
+      )
       expect(setFailedMock).not.toHaveBeenCalled()
     })
   })
@@ -284,6 +294,16 @@ describe('action', () => {
         1,
         'bundle-path',
         expect.stringMatching('attestation.json')
+      )
+      expect(setOutputMock).toHaveBeenNthCalledWith(
+        2,
+        'attestation-id',
+        expect.stringMatching(attestationID)
+      )
+      expect(setOutputMock).toHaveBeenNthCalledWith(
+        3,
+        'attestation-url',
+        expect.stringContaining(`foo/bar/attestations/${attestationID}`)
       )
       expect(setFailedMock).not.toHaveBeenCalled()
     })

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,10 @@ inputs:
 outputs:
   bundle-path:
     description: 'The path to the file containing the attestation bundle.'
+  attestation-id:
+    description: 'The ID of the attestation.'
+  attestation-url:
+    description: 'The URL for the attestation summary.'
 
 runs:
   using: node20

--- a/dist/index.js
+++ b/dist/index.js
@@ -70970,6 +70970,10 @@ async function run(inputs) {
             encoding: 'utf-8',
             flag: 'a'
         });
+        if (att.attestationID) {
+            core.setOutput('attestation-id', att.attestationID);
+            core.setOutput('attestation-url', attestationURL(att.attestationID));
+        }
         if (inputs.showSummary) {
             logSummary(att);
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actions/attest",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "actions/attest",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@actions/attest": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "actions/attest",
   "description": "Generate signed attestations for workflow artifacts",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "author": "",
   "private": true,
   "homepage": "https://github.com/actions/attest",

--- a/src/main.ts
+++ b/src/main.ts
@@ -79,6 +79,11 @@ export async function run(inputs: RunInputs): Promise<void> {
       flag: 'a'
     })
 
+    if (att.attestationID) {
+      core.setOutput('attestation-id', att.attestationID)
+      core.setOutput('attestation-url', attestationURL(att.attestationID))
+    }
+
     if (inputs.showSummary) {
       logSummary(att)
     }


### PR DESCRIPTION
Updates the outputs of the action to include two new values:

* `attestation-id` - the GitHub ID for the attestation
* `attestation-url` - the URL to the attestation summary page

Previously, it was impractical to support these outputs due to the fact that the v1 version of this action generated multiple attestations at the same time. Now, with multi-subject attestations, each invocation of the action generates a single attestation -- making it possible to return a single attestation ID and URL.

Per https://github.com/actions/attest-build-provenance/issues/126