### PR TITLE
New subject-checksums input param

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,19 +74,24 @@ See [action.yml](action.yml)
 - uses: actions/attest@v2
   with:
     # Path to the artifact serving as the subject of the attestation. Must
-    # specify exactly one of "subject-path" or "subject-digest". May contain
-    # a glob pattern or list of paths (total subject count cannot exceed 1024).
+    # specify exactly one of "subject-path", "subject-digest", or
+    # "subject-checksums". May contain a glob pattern or list of paths
+    # (total subject count cannot exceed 1024).
     subject-path:
 
     # SHA256 digest of the subject for the attestation. Must be in the form
     # "sha256:hex_digest" (e.g. "sha256:abc123..."). Must specify exactly one
-    # of "subject-path" or "subject-digest".
+    # of "subject-path", "subject-digest", or "subject-checksums".
     subject-digest:
 
-    # Subject name as it should appear in the attestation. Required unless
-    # "subject-path" is specified, in which case it will be inferred from the
-    # path.
+    # Subject name as it should appear in the attestation. Required when
+    # identifying the subject with the "subject-digest" input.
     subject-name:
+
+    # Path to checksums file containing digest and name of subjects for
+    # attestation. Must specify exactly one of "subject-path", "subject-digest",
+    # or "subject-checksums".
+    subject-checksums:
 
     # URI identifying the type of the predicate.
     predicate-type:
@@ -207,6 +212,43 @@ newline delimited list:
     subject-path: |
       dist/foo
       dist/bar
+```
+
+### Identify Subjects with Checksums File
+
+If you are using tools like
+[goreleaser](https://goreleaser.com/customization/checksum/) or
+[jreleaser](https://jreleaser.org/guide/latest/reference/checksum.html) which
+generate a checksums file you can identify the attestation subjects by passing
+the path of the checksums file to the `subject-checksums` input. Each of the
+artifacts identified in the checksums file will be listed as a subject for the
+attestation.
+
+```yaml
+- name: Calculate artifact digests
+  run: |
+    shasum -a 256 foo_0.0.1_* > subject.checksums.txt
+
+- uses: actions/attest@v2
+  with:
+    subject-checksums: subject.checksums.txt
+    predicate-type: 'https://example.com/predicate/v1'
+    predicate: '{}'
+```
+
+<!-- markdownlint-disable MD038 -->
+
+The file referenced by the `subject-checksums` input must conform to the same
+format used by the shasum tools. Each subject should be listed on a separate
+line including the hex-encoded digest (either SHA256 or SHA512), a space, a
+single character flag indicating either binary (`*`) or text (` `) input mode,
+and the filename.
+
+<!-- markdownlint-enable MD038 -->
+
+```text
+b569bf992b287f55d78bf8ee476497e9b7e9d2bf1c338860bfb905016218c740  foo_0.0.1_darwin_amd64
+a54fc515e616cac7fcf11a49d5c5ec9ec315948a5935c1e11dd610b834b14dde  foo_0.0.1_darwin_arm64
 ```
 
 ### Container Image

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -43,6 +43,7 @@ const defaultInputs: main.RunInputs = {
   subjectName: '',
   subjectDigest: '',
   subjectPath: '',
+  subjectChecksums: '',
   pushToRegistry: false,
   showSummary: true,
   githubToken: '',
@@ -138,7 +139,9 @@ describe('action', () => {
 
       expect(runMock).toHaveReturned()
       expect(setFailedMock).toHaveBeenCalledWith(
-        new Error('One of subject-path or subject-digest must be provided')
+        new Error(
+          'One of subject-path, subject-digest, or subject-checksums must be provided'
+        )
       )
     })
   })

--- a/__tests__/subject.test.ts
+++ b/__tests__/subject.test.ts
@@ -517,6 +517,20 @@ f861e68a080799ca83104630b56abb90d8dbcc5f8b5a8639cb691e269838f29e  demo_0.0.1_lin
       )
     })
   })
+
+  describe('when specifying a subject checksums string with an invalid digest', () => {
+    const checksums =
+      '!!!!e68a080799ca83104630b56abb90d8dbcc5f8b5a8639cb691e269838f29e  demo_0.0.1_linux_386'
+
+    it('throws an error', async () => {
+      const inputs: SubjectInputs = {
+        ...blankInputs,
+        subjectChecksums: checksums
+      }
+
+      await expect(subjectFromInputs(inputs)).rejects.toThrow(/invalid digest/i)
+    })
+  })
 })
 
 describe('subjectDigest', () => {

--- a/action.yml
+++ b/action.yml
@@ -9,20 +9,26 @@ inputs:
   subject-path:
     description: >
       Path to the artifact serving as the subject of the attestation. Must
-      specify exactly one of "subject-path" or "subject-digest". May contain a
-      glob pattern or list of paths (total subject count cannot exceed 1024).
+      specify exactly one of "subject-path",  "subject-digest", or
+      "subject-checksums". May contain a glob pattern or list of paths (total
+      subject count cannot exceed 1024).
     required: false
   subject-digest:
     description: >
       Digest of the subject for the attestation. Must be in the form
       "algorithm:hex_digest" (e.g. "sha256:abc123..."). Must specify exactly one
-      of "subject-path" or "subject-digest".
+      of "subject-path", "subject-digest", or "subject-checksums".
     required: false
   subject-name:
     description: >
-      Subject name as it should appear in the attestation. Required unless
-      "subject-path" is specified, in which case it will be inferred from the
-      path.
+      Subject name as it should appear in the attestation. Required when
+      identifying the subject with the "subject-digest" input.
+    required: false
+  subject-checksums:
+    description: >
+      Path to checksums file containing digest and name of subjects for
+      attestation. Must specify exactly one of "subject-path", "subject-digest",
+      or "subject-checksums".
     required: false
   predicate-type:
     description: >

--- a/dist/index.js
+++ b/dist/index.js
@@ -71139,6 +71139,7 @@ const path_1 = __importDefault(__nccwpck_require__(16928));
 const MAX_SUBJECT_COUNT = 1024;
 const MAX_SUBJECT_CHECKSUM_SIZE_BYTES = 512 * MAX_SUBJECT_COUNT;
 const DIGEST_ALGORITHM = 'sha256';
+const HEX_STRING_RE = /^[0-9a-fA-F]+$/;
 // Returns the subject specified by the action's inputs. The subject may be
 // specified as a path to a file or as a digest. If a path is provided, the
 // file's digest is calculated and returned along with the subject's name. If a
@@ -71250,6 +71251,9 @@ const getSubjectFromChecksumsString = (checksums) => {
         // Swallow the type identifier character at the beginning of the name
         const name = record.slice(delimIndex + 2);
         const digest = record.slice(0, delimIndex);
+        if (!HEX_STRING_RE.test(digest)) {
+            throw new Error(`Invalid digest: ${digest}`);
+        }
         subjects.push({
             name,
             digest: { [digestAlgorithm(digest)]: digest }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ const inputs: RunInputs = {
   subjectPath: core.getInput('subject-path'),
   subjectName: core.getInput('subject-name'),
   subjectDigest: core.getInput('subject-digest'),
+  subjectChecksums: core.getInput('subject-checksums'),
   predicateType: core.getInput('predicate-type'),
   predicate: core.getInput('predicate'),
   predicatePath: core.getInput('predicate-path'),

--- a/src/subject.ts
+++ b/src/subject.ts
@@ -11,6 +11,7 @@ import type { Subject } from '@actions/attest'
 const MAX_SUBJECT_COUNT = 1024
 const MAX_SUBJECT_CHECKSUM_SIZE_BYTES = 512 * MAX_SUBJECT_COUNT
 const DIGEST_ALGORITHM = 'sha256'
+const HEX_STRING_RE = /^[0-9a-fA-F]+$/
 
 export type SubjectInputs = {
   subjectPath: string
@@ -183,6 +184,10 @@ const getSubjectFromChecksumsString = (checksums: string): Subject[] => {
     // Swallow the type identifier character at the beginning of the name
     const name = record.slice(delimIndex + 2)
     const digest = record.slice(0, delimIndex)
+
+    if (!HEX_STRING_RE.test(digest)) {
+      throw new Error(`Invalid digest: ${digest}`)
+    }
 
     subjects.push({
       name,

--- a/src/subject.ts
+++ b/src/subject.ts
@@ -1,18 +1,22 @@
 import * as glob from '@actions/glob'
+import assert from 'assert'
 import crypto from 'crypto'
 import { parse } from 'csv-parse/sync'
 import fs from 'fs'
+import os from 'os'
 import path from 'path'
 
 import type { Subject } from '@actions/attest'
 
 const MAX_SUBJECT_COUNT = 1024
+const MAX_SUBJECT_CHECKSUM_SIZE_BYTES = 512 * MAX_SUBJECT_COUNT
 const DIGEST_ALGORITHM = 'sha256'
 
 export type SubjectInputs = {
   subjectPath: string
   subjectName: string
   subjectDigest: string
+  subjectChecksums: string
   downcaseName?: boolean
 }
 // Returns the subject specified by the action's inputs. The subject may be
@@ -22,15 +26,26 @@ export type SubjectInputs = {
 export const subjectFromInputs = async (
   inputs: SubjectInputs
 ): Promise<Subject[]> => {
-  const { subjectPath, subjectDigest, subjectName, downcaseName } = inputs
+  const {
+    subjectPath,
+    subjectDigest,
+    subjectName,
+    subjectChecksums,
+    downcaseName
+  } = inputs
 
-  if (!subjectPath && !subjectDigest) {
-    throw new Error('One of subject-path or subject-digest must be provided')
+  const enabledInputs = [subjectPath, subjectDigest, subjectChecksums].filter(
+    Boolean
+  )
+  if (enabledInputs.length === 0) {
+    throw new Error(
+      'One of subject-path, subject-digest, or subject-checksums must be provided'
+    )
   }
 
-  if (subjectPath && subjectDigest) {
+  if (enabledInputs.length > 1) {
     throw new Error(
-      'Only one of subject-path or subject-digest may be provided'
+      'Only one of subject-path, subject-digest, or subject-checksums may be provided'
     )
   }
 
@@ -42,10 +57,17 @@ export const subjectFromInputs = async (
   // to conform to OCI image naming conventions
   const name = downcaseName ? subjectName.toLowerCase() : subjectName
 
-  if (subjectPath) {
-    return await getSubjectFromPath(subjectPath, name)
-  } else {
-    return [getSubjectFromDigest(subjectDigest, name)]
+  switch (true) {
+    case !!subjectPath:
+      return getSubjectFromPath(subjectPath, name)
+    case !!subjectDigest:
+      return [getSubjectFromDigest(subjectDigest, name)]
+    case !!subjectChecksums:
+      return getSubjectFromChecksums(subjectChecksums)
+    /* istanbul ignore next */
+    default:
+      // This should be unreachable, but TS requires a default case
+      assert.fail('unreachable')
   }
 }
 
@@ -65,7 +87,7 @@ const getSubjectFromPath = async (
   const digestedSubjects: Subject[] = []
 
   // Parse the list of subject paths
-  const subjectPaths = parseList(subjectPath).join('\n')
+  const subjectPaths = parseSubjectPathList(subjectPath).join('\n')
 
   // Expand the globbed paths to a list of actual paths
   const paths = await glob.create(subjectPaths).then(async g => g.glob())
@@ -119,6 +141,58 @@ const getSubjectFromDigest = (
   }
 }
 
+const getSubjectFromChecksums = (subjectChecksums: string): Subject[] => {
+  if (fs.existsSync(subjectChecksums)) {
+    return getSubjectFromChecksumsFile(subjectChecksums)
+  } else {
+    return getSubjectFromChecksumsString(subjectChecksums)
+  }
+}
+
+const getSubjectFromChecksumsFile = (checksumsPath: string): Subject[] => {
+  const stats = fs.statSync(checksumsPath)
+  if (!stats.isFile()) {
+    throw new Error(`subject checksums file not found: ${checksumsPath}`)
+  }
+
+  /* istanbul ignore next */
+  if (stats.size > MAX_SUBJECT_CHECKSUM_SIZE_BYTES) {
+    throw new Error(
+      `subject checksums file exceeds maximum allowed size: ${MAX_SUBJECT_CHECKSUM_SIZE_BYTES} bytes`
+    )
+  }
+
+  const checksums = fs.readFileSync(checksumsPath, 'utf-8')
+  return getSubjectFromChecksumsString(checksums)
+}
+
+const getSubjectFromChecksumsString = (checksums: string): Subject[] => {
+  const subjects: Subject[] = []
+
+  const records: string[] = checksums.split(os.EOL).filter(Boolean)
+
+  for (const record of records) {
+    // Find the space delimiter following the digest
+    const delimIndex = record.indexOf(' ')
+
+    // Skip any line that doesn't have a delimiter
+    if (delimIndex === -1) {
+      continue
+    }
+
+    // Swallow the type identifier character at the beginning of the name
+    const name = record.slice(delimIndex + 2)
+    const digest = record.slice(0, delimIndex)
+
+    subjects.push({
+      name,
+      digest: { [digestAlgorithm(digest)]: digest }
+    })
+  }
+
+  return subjects
+}
+
 // Calculates the digest of a file using the specified algorithm. The file is
 // streamed into the digest function to avoid loading the entire file into
 // memory. The returned digest is a hex string.
@@ -135,7 +209,7 @@ const digestFile = async (
   })
 }
 
-const parseList = (input: string): string[] => {
+const parseSubjectPathList = (input: string): string[] => {
   const res: string[] = []
 
   const records: string[][] = parse(input, {
@@ -150,4 +224,15 @@ const parseList = (input: string): string[] => {
   }
 
   return res.filter(item => item).map(pat => pat.trim())
+}
+
+const digestAlgorithm = (digest: string): string => {
+  switch (digest.length) {
+    case 64:
+      return 'sha256'
+    case 128:
+      return 'sha512'
+    default:
+      throw new Error(`Unknown digest algorithm: ${digest}`)
+  }
 }


### PR DESCRIPTION
Adds support for a new `subject-checksums` input parameter which allows the user to identify the attestation subjects by passing the path of the checksums file.

This enables direct integration with tools like goreleaser, jreleaser, and the sha*sum suite of tools which generate a checksums file.