### PR TITLE
bump @actions/attest from 1.5.0 to 1.6.0

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Lint Codebase
         id: super-linter
-        uses: super-linter/super-linter/slim@v7
+        uses: super-linter/super-linter/slim@v7.2.1
         env:
           DEFAULT_BRANCH: main
           FILTER_REGEX_EXCLUDE: dist/**/*

--- a/dist/index.js
+++ b/dist/index.js
@@ -377,11 +377,9 @@ const buildSLSAProvenancePredicate = (issuer) => __awaiter(void 0, void 0, void 
     // Split just the path and ref from the workflow string.
     // owner/repo/.github/workflows/main.yml@main =>
     //   .github/workflows/main.yml, main
-    const [workflowPath, ...workflowRefChunks] = claims.workflow_ref
+    const [workflowPath] = claims.workflow_ref
         .replace(`${claims.repository}/`, '')
         .split('@');
-    // Handle case where tag contains `@` (e.g: when using changesets in a monorepo context),
-    const workflowRef = workflowRefChunks.join('@');
     return {
         type: SLSA_PREDICATE_V1_TYPE,
         params: {
@@ -389,7 +387,7 @@ const buildSLSAProvenancePredicate = (issuer) => __awaiter(void 0, void 0, void 
                 buildType: GITHUB_BUILD_TYPE,
                 externalParameters: {
                     workflow: {
-                        ref: workflowRef,
+                        ref: claims.ref,
                         repository: `${serverURL}/${claims.repository}`,
                         path: workflowPath
                     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "actions/attest",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "actions/attest",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
-        "@actions/attest": "^1.5.0",
+        "@actions/attest": "^1.6.0",
         "@actions/core": "^1.11.1",
         "@actions/github": "^6.0.0",
         "@actions/glob": "^0.5.0",
@@ -49,9 +49,9 @@
       }
     },
     "node_modules/@actions/attest": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@actions/attest/-/attest-1.5.0.tgz",
-      "integrity": "sha512-KIalYPhJu0/6LOhT+Bhw0GncresPCiY1onLq8n0whjoJX0/M7UQmgXkn1ioQnNrkzEhcs6wVKwylusbMwTOX0g==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@actions/attest/-/attest-1.6.0.tgz",
+      "integrity": "sha512-D+VcLqUImA7Gr5qPQrRGvNUJKzP67IHV3/ofF5QBpLqe3Vih3hb74k9ZtjHXamiZNVZi2Wkphj8yTi4/xiWkwQ==",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",
@@ -8831,9 +8831,9 @@
       "dev": true
     },
     "@actions/attest": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@actions/attest/-/attest-1.5.0.tgz",
-      "integrity": "sha512-KIalYPhJu0/6LOhT+Bhw0GncresPCiY1onLq8n0whjoJX0/M7UQmgXkn1ioQnNrkzEhcs6wVKwylusbMwTOX0g==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@actions/attest/-/attest-1.6.0.tgz",
+      "integrity": "sha512-D+VcLqUImA7Gr5qPQrRGvNUJKzP67IHV3/ofF5QBpLqe3Vih3hb74k9ZtjHXamiZNVZi2Wkphj8yTi4/xiWkwQ==",
       "requires": {
         "@actions/core": "^1.11.1",
         "@actions/github": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "actions/attest",
   "description": "Generate signed attestations for workflow artifacts",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": "",
   "private": true,
   "homepage": "https://github.com/actions/attest",
@@ -69,7 +69,7 @@
     ]
   },
   "dependencies": {
-    "@actions/attest": "^1.5.0",
+    "@actions/attest": "^1.6.0",
     "@actions/core": "^1.11.1",
     "@actions/github": "^6.0.0",
     "@actions/glob": "^0.5.0",


### PR DESCRIPTION
Update the `@actions/attest` package from 1.5.0 to 1.6.0. Includes the following:

* https://github.com/actions/toolkit/pull/1969