### PR TITLE
Add path to created attestation in a well-known summary file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ initiated.
 
 When an attestation is created, the attestation is stored on the local filesystem
 used by the runner. For each attestation created, the filesystem path will be
-appended to the file `/tmp/created_attestation_paths.txt`. This can be used to
-gather all attestations created by all jobs during a the workflow.
+appended to the file `${RUNNER_TEMP}$/created_attestation_paths.txt`. This can be
+used to gather all attestations created by all jobs during a the workflow.
 
 Attestations can be verified using the [`attestation` command in the GitHub
 CLI][5].

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Once the attestation has been created and signed, it will be uploaded to the GH
 attestations API and associated with the repository from which the workflow was
 initiated.
 
+When an attestation is created, the attestation is stored on the local filesystem
+used by the runner. For each attestation created, the filesystem path will be
+appended to the file `/tmp/created_attestation_paths.txt`. This can be used to
+gather all attestations created by all jobs during a the workflow.
+
 Attestations can be verified using the [`attestation` command in the GitHub
 CLI][5].
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -71130,10 +71130,7 @@ const predicate_1 = __nccwpck_require__(84982);
 const style = __importStar(__nccwpck_require__(64542));
 const subject_1 = __nccwpck_require__(36303);
 const ATTESTATION_FILE_NAME = 'attestation.json';
-// The attestations paths file is part of the API, and so should not be made
-// configurable. Other steps or summary jobs can read this file to find all the
-// attestation paths created by this action.
-const ATTESTATION_PATHS_FILE_NAME = '/tmp/created_attestation_paths.txt';
+const ATTESTATION_PATHS_FILE_NAME = 'created_attestation_paths.txt';
 /* istanbul ignore next */
 const logHandler = (level, ...args) => {
     // Send any HTTP-related log events to the GitHub Actions debug log
@@ -71176,8 +71173,10 @@ async function run(inputs) {
             encoding: 'utf-8',
             flag: 'a'
         });
+        const baseDir = process.env.RUNNER_TEMP || tempDir();
+        const outputSummaryPath = path_1.default.join(baseDir, ATTESTATION_PATHS_FILE_NAME);
         // Append the output path to the attestations paths file
-        fs_1.default.appendFileSync(ATTESTATION_PATHS_FILE_NAME, outputPath + os_1.default.EOL, {
+        fs_1.default.appendFileSync(outputSummaryPath, outputPath + os_1.default.EOL, {
             encoding: 'utf-8',
             flag: 'a'
         });

--- a/dist/index.js
+++ b/dist/index.js
@@ -71130,6 +71130,10 @@ const predicate_1 = __nccwpck_require__(84982);
 const style = __importStar(__nccwpck_require__(64542));
 const subject_1 = __nccwpck_require__(36303);
 const ATTESTATION_FILE_NAME = 'attestation.json';
+// The attestations paths file is part of the API, and so should not be made
+// configurable. Other steps or summary jobs can read this file to find all the
+// attestation paths created by this action.
+const ATTESTATION_PATHS_FILE_NAME = '/tmp/created_attestation_paths.txt';
 /* istanbul ignore next */
 const logHandler = (level, ...args) => {
     // Send any HTTP-related log events to the GitHub Actions debug log
@@ -71169,6 +71173,11 @@ async function run(inputs) {
         logAttestation(subjects, att, sigstoreInstance);
         // Write attestation bundle to output file
         fs_1.default.writeFileSync(outputPath, JSON.stringify(att.bundle) + os_1.default.EOL, {
+            encoding: 'utf-8',
+            flag: 'a'
+        });
+        // Append the output path to the attestations paths file
+        fs_1.default.appendFileSync(ATTESTATION_PATHS_FILE_NAME, outputPath + os_1.default.EOL, {
             encoding: 'utf-8',
             flag: 'a'
         });

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,10 +16,7 @@ import {
 import type { Subject } from '@actions/attest'
 
 const ATTESTATION_FILE_NAME = 'attestation.json'
-// The attestations paths file is part of the API, and so should not be made
-// configurable. Other steps or summary jobs can read this file to find all the
-// attestation paths created by this action.
-const ATTESTATION_PATHS_FILE_NAME = '/tmp/created_attestation_paths.txt'
+const ATTESTATION_PATHS_FILE_NAME = 'created_attestation_paths.txt'
 
 export type RunInputs = SubjectInputs &
   PredicateInputs & {
@@ -83,8 +80,10 @@ export async function run(inputs: RunInputs): Promise<void> {
       flag: 'a'
     })
 
+    const baseDir = process.env.RUNNER_TEMP || tempDir()
+    const outputSummaryPath = path.join(baseDir, ATTESTATION_PATHS_FILE_NAME)
     // Append the output path to the attestations paths file
-    fs.appendFileSync(ATTESTATION_PATHS_FILE_NAME, outputPath + os.EOL, {
+    fs.appendFileSync(outputSummaryPath, outputPath + os.EOL, {
       encoding: 'utf-8',
       flag: 'a'
     })

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,10 @@ import {
 import type { Subject } from '@actions/attest'
 
 const ATTESTATION_FILE_NAME = 'attestation.json'
+// The attestations paths file is part of the API, and so should not be made
+// configurable. Other steps or summary jobs can read this file to find all the
+// attestation paths created by this action.
+const ATTESTATION_PATHS_FILE_NAME = '/tmp/created_attestation_paths.txt'
 
 export type RunInputs = SubjectInputs &
   PredicateInputs & {
@@ -75,6 +79,12 @@ export async function run(inputs: RunInputs): Promise<void> {
 
     // Write attestation bundle to output file
     fs.writeFileSync(outputPath, JSON.stringify(att.bundle) + os.EOL, {
+      encoding: 'utf-8',
+      flag: 'a'
+    })
+
+    // Append the output path to the attestations paths file
+    fs.appendFileSync(ATTESTATION_PATHS_FILE_NAME, outputPath + os.EOL, {
       encoding: 'utf-8',
       flag: 'a'
     })


### PR DESCRIPTION
For a situation where multiple attestations are created in a workflow, write the path to each file in a well-known file. This allows for creation of summary steps that can easily read this and act on the created attestations, without knowing about all the steps and their id:s.

The file chosen to be the well-known file is `${RUNNER_TEMP}/created_attestation_paths.txt`. Each attestation is appended to that file, one path to an attestation per line.