### PR TITLE
Improved checksum parsing

### DIFF
--- a/__tests__/subject.test.ts
+++ b/__tests__/subject.test.ts
@@ -473,6 +473,13 @@ badline
               '187dcd1506a170337415589ff00c8743f19d41cc31fca246c2739dfd450d0b9d'
           }
         })
+        expect(subjects).toContainEqual({
+          name: 'demo_0.0.1_darwin_arm64',
+          digest: {
+            sha512:
+              '5d8b4751ef31f9440d843fcfa4e53ca2e25b1cb1f13fd355fdc7c24b41fe645293291ea9297ba3989078abb77ebbaac66be073618a9e4974dbd0361881d4c718'
+          }
+        })
       })
     })
   })
@@ -480,8 +487,8 @@ badline
   describe('when specifying a subject checksums string', () => {
     const checksums = `
 f861e68a080799ca83104630b56abb90d8dbcc5f8b5a8639cb691e269838f29e  demo_0.0.1_linux_386
-187dcd1506a170337415589ff00c8743f19d41cc31fca246c2739dfd450d0b9d  demo_0.0.1_linux_amd64
-9ecbf449e286a8a8748c161c52aa28b6b2fc64ab86f94161c5d1b3abc18156c5  demo_0.0.1_linux_arm64`
+187dcd1506a170337415589ff00c8743f19d41cc31fca246c2739dfd450d0b9d *demo_0.0.1_linux_amd64
+9ecbf449e286a8a8748c161c52aa28b6b2fc64ab86f94161c5d1b3abc18156c5 demo_0.0.1_linux_arm64`
 
     it('returns the multiple subjects', async () => {
       const inputs: SubjectInputs = {
@@ -498,6 +505,20 @@ f861e68a080799ca83104630b56abb90d8dbcc5f8b5a8639cb691e269838f29e  demo_0.0.1_lin
         digest: {
           sha256:
             'f861e68a080799ca83104630b56abb90d8dbcc5f8b5a8639cb691e269838f29e'
+        }
+      })
+      expect(subjects).toContainEqual({
+        name: 'demo_0.0.1_linux_amd64',
+        digest: {
+          sha256:
+            '187dcd1506a170337415589ff00c8743f19d41cc31fca246c2739dfd450d0b9d'
+        }
+      })
+      expect(subjects).toContainEqual({
+        name: 'demo_0.0.1_linux_arm64',
+        digest: {
+          sha256:
+            '9ecbf449e286a8a8748c161c52aa28b6b2fc64ab86f94161c5d1b3abc18156c5'
         }
       })
     })

--- a/dist/index.js
+++ b/dist/index.js
@@ -74225,8 +74225,12 @@ const getSubjectFromChecksumsString = (checksums) => {
         if (delimIndex === -1) {
             continue;
         }
-        // Swallow the type identifier character at the beginning of the name
-        const name = record.slice(delimIndex + 2);
+        // It's common for checksum records to have a leading flag character before
+        // the artifact name. It will be either a '*' or a space.
+        const flag_and_name = record.slice(delimIndex + 1);
+        const name = flag_and_name.startsWith('*') || flag_and_name.startsWith(' ')
+            ? flag_and_name.slice(1)
+            : flag_and_name;
         const digest = record.slice(0, delimIndex);
         if (!HEX_STRING_RE.test(digest)) {
             throw new Error(`Invalid digest: ${digest}`);

--- a/src/subject.ts
+++ b/src/subject.ts
@@ -181,8 +181,14 @@ const getSubjectFromChecksumsString = (checksums: string): Subject[] => {
       continue
     }
 
-    // Swallow the type identifier character at the beginning of the name
-    const name = record.slice(delimIndex + 2)
+    // It's common for checksum records to have a leading flag character before
+    // the artifact name. It will be either a '*' or a space.
+    const flag_and_name = record.slice(delimIndex + 1)
+    const name =
+      flag_and_name.startsWith('*') || flag_and_name.startsWith(' ')
+        ? flag_and_name.slice(1)
+        : flag_and_name
+
     const digest = record.slice(0, delimIndex)
 
     if (!HEX_STRING_RE.test(digest)) {


### PR DESCRIPTION
Per: https://github.com/actions/attest-build-provenance/issues/454#issuecomment-3208639809

Improve parsing of checksums files to make more tolerant of different formats.

Most tools which generate checksums follow the [guidance](https://www.gnu.org/software/coreutils/manual/coreutils.html#cksum-output-modes-1) for the GNU md5sum tool:

> For each file, we print the checksum, a space, a flag indicating binary or text input mode, and the file name. Binary mode is indicated with ‘*’, text mode with ‘ ’ (space). Binary mode is the default on systems where it’s significant, otherwise text mode is the default.

However, not all tools include the input mode flag. This change will updating the parsing logic to make it tolerant of tools which don't include the input mode flag.