### PR TITLE
ci: auto-rebuild dist/ for Dependabot production bumps

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -45,7 +45,10 @@ jobs:
         id: build
         run: npm run bundle
 
-      # This will fail the workflow if the PR wasn't created by Dependabot.
+      # Fail the workflow if the checked-in dist/ differs from a fresh build.
+      # Dependabot production-dependency bumps are rebuilt and committed
+      # automatically by the rebuild-dist.yml / commit-dist.yml workflows; any
+      # other stale dist/ must be rebuilt and pushed by hand.
       - name: Compare Directories
         id: diff
         run: |
@@ -55,8 +58,8 @@ jobs:
             exit 1
           fi
 
-      # If `dist/` was different than expected, and this was not a Dependabot
-      # PR, upload the expected version as a workflow artifact.
+      # If dist/ was different than expected, upload the freshly-built version
+      # as a workflow artifact so it can be downloaded and committed manually.
       - if: ${{ failure() && steps.diff.outcome == 'failure' }}
         name: Upload Artifact
         id: upload

--- a/.github/workflows/commit-dist.yml
+++ b/.github/workflows/commit-dist.yml
@@ -1,0 +1,90 @@
+# Consumes the artifact from `rebuild-dist.yml` and commits the rebuilt `dist/`
+# back to the Dependabot PR branch. This half is PRIVILEGED (contents: write)
+# but it never runs any code from the PR — it only moves already-built bytes and
+# git-pushes them. Because it triggers on workflow_run, the workflow definition
+# executed here is the trusted copy from the default branch.
+#
+# NOTE: pushes made with the default GITHUB_TOKEN do NOT re-trigger `on:
+# pull_request` workflows, so `check-dist.yml` will not automatically re-verify
+# the committed dist/. The verify-head guard below is our integrity check.
+name: Commit dist
+
+on:
+  workflow_run:
+    workflows: ["Rebuild dist"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  commit:
+    name: Commit dist/
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    # Only proceed for successful builder runs that were triggered by a PR.
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download rebuilt dist/
+        id: download
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: rebuilt-dist
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: incoming
+
+      # No artifact => the builder found dist/ already up to date. Nothing to do.
+      - name: Check for artifact
+        id: check
+        run: |
+          if [ -d incoming/dist ] && [ -f incoming/dist-meta/head-ref ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+            echo "head-ref=$(cat incoming/dist-meta/head-ref)" >> "$GITHUB_OUTPUT"
+            echo "head-sha=$(cat incoming/dist-meta/head-sha)" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout PR branch
+        if: steps.check.outputs.present == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ steps.check.outputs.head-ref }}
+          token: ${{ github.token }}
+
+      # Guard against a race: if the PR branch advanced after the builder ran,
+      # bail rather than committing a dist/ built from a stale tree.
+      - name: Verify head is unchanged
+        if: steps.check.outputs.present == 'true'
+        run: |
+          current="$(git rev-parse HEAD)"
+          if [ "$current" != "${{ steps.check.outputs.head-sha }}" ]; then
+            echo "PR branch moved ($current != ${{ steps.check.outputs.head-sha }}); skipping."
+            exit 1
+          fi
+
+      - name: Apply rebuilt dist/
+        if: steps.check.outputs.present == 'true'
+        run: |
+          rm -rf dist
+          mv incoming/dist dist
+          rm -rf incoming
+
+      - name: Commit and push
+        if: steps.check.outputs.present == 'true'
+        run: |
+          if git diff --quiet -- dist/; then
+            echo "dist/ already current; nothing to commit."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add dist/
+          git commit -m "build: rebuild dist/ for dependency bump"
+          git push origin HEAD:${{ steps.check.outputs.head-ref }}

--- a/.github/workflows/commit-dist.yml
+++ b/.github/workflows/commit-dist.yml
@@ -40,16 +40,32 @@ jobs:
           path: incoming
 
       # No artifact => the builder found dist/ already up to date. Nothing to do.
+      # The head-ref/head-sha values come from an artifact produced in the
+      # (unprivileged) PR context, so validate them strictly before writing to
+      # $GITHUB_OUTPUT to avoid workflow-command injection.
       - name: Check for artifact
         id: check
         run: |
-          if [ -d incoming/dist ] && [ -f incoming/dist-meta/head-ref ]; then
-            echo "present=true" >> "$GITHUB_OUTPUT"
-            echo "head-ref=$(cat incoming/dist-meta/head-ref)" >> "$GITHUB_OUTPUT"
-            echo "head-sha=$(cat incoming/dist-meta/head-sha)" >> "$GITHUB_OUTPUT"
-          else
+          if [ ! -d incoming/dist ] || [ ! -f incoming/dist-meta/head-ref ] || [ ! -f incoming/dist-meta/head-sha ]; then
             echo "present=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          head_ref="$(head -n1 incoming/dist-meta/head-ref | tr -d '\r\n')"
+          head_sha="$(head -n1 incoming/dist-meta/head-sha | tr -d '\r\n')"
+
+          if ! printf '%s' "$head_sha" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "Invalid head-sha; refusing to proceed." >&2
+            exit 1
+          fi
+          if ! printf '%s' "$head_ref" | grep -Eq '^[A-Za-z0-9._/-]+$'; then
+            echo "Invalid head-ref; refusing to proceed." >&2
+            exit 1
+          fi
+
+          echo "present=true" >> "$GITHUB_OUTPUT"
+          echo "head-ref=$head_ref" >> "$GITHUB_OUTPUT"
+          echo "head-sha=$head_sha" >> "$GITHUB_OUTPUT"
 
       - name: Checkout PR branch
         if: steps.check.outputs.present == 'true'

--- a/.github/workflows/rebuild-dist.yml
+++ b/.github/workflows/rebuild-dist.yml
@@ -1,0 +1,77 @@
+# Rebuilds the transpiled `dist/` for Dependabot production-dependency bumps.
+# This half is deliberately UNPRIVILEGED: it runs in the pull_request context
+# with a read-only token and no secrets, so freshly-bumped (and therefore
+# untrusted) dependency code never coexists with a write credential. It only
+# produces artifacts; the privileged `commit-dist.yml` workflow consumes them.
+name: Rebuild dist
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  rebuild:
+    name: Rebuild dist/
+    # Only Dependabot PRs are eligible; everything else is covered by check-dist.
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+
+      - name: Checkout
+        if: steps.meta.outputs.dependency-type == 'direct:production'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Node.js
+        if: steps.meta.outputs.dependency-type == 'direct:production'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      # --ignore-scripts prevents lifecycle scripts of the bumped dependency
+      # from running during install; the bundle step is the only build we run.
+      - name: Install Dependencies
+        if: steps.meta.outputs.dependency-type == 'direct:production'
+        run: npm ci --ignore-scripts
+
+      - name: Build dist/ Directory
+        if: steps.meta.outputs.dependency-type == 'direct:production'
+        run: npm run bundle
+
+      - name: Detect dist/ changes
+        id: diff
+        if: steps.meta.outputs.dependency-type == 'direct:production'
+        run: |
+          if [ "$(git diff --ignore-space-at-eol --text dist/ | wc -l)" -gt "0" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Persist the context the privileged workflow needs. workflow_run cannot
+      # trust head_ref from its own event payload alone, so we hand it over
+      # explicitly as artifact metadata.
+      - name: Record PR context
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          mkdir -p dist-meta
+          echo "${{ github.event.pull_request.number }}"   > dist-meta/pr-number
+          echo "${{ github.event.pull_request.head.ref }}" > dist-meta/head-ref
+          echo "${{ github.event.pull_request.head.sha }}" > dist-meta/head-sha
+
+      - name: Upload rebuilt dist/
+        if: steps.diff.outputs.changed == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rebuilt-dist
+          path: |
+            dist/
+            dist-meta/
+          retention-days: 1

--- a/.github/workflows/rebuild-dist.yml
+++ b/.github/workflows/rebuild-dist.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read # required by dependabot/fetch-metadata
 
 jobs:
   rebuild:


### PR DESCRIPTION
## What

Adds a two-workflow pipeline that automatically rebuilds the transpiled `dist/` whenever Dependabot bumps a **production** dependency, so consumers of the action get the updated JavaScript without waiting on a manual rebuild.

## Why

Today `check-dist.yml` *detects* a stale `dist/` and fails the PR, but a human still has to rebuild and push. Every Dependabot prod-dep bump goes red until someone does that by hand.

## How

Split across two workflows so untrusted, freshly-bumped dependency code never runs in a job that holds a write token:

- **`rebuild-dist.yml`** — runs unprivileged on the PR (`contents: read`, no secrets, `npm ci --ignore-scripts`). Gated to `github.actor == 'dependabot[bot]'` and `dependency-type == 'direct:production'` via `dependabot/fetch-metadata`. Rebuilds `dist/`; if it changed, uploads the bytes plus PR context (`head-ref`/`head-sha`) as an artifact.
- **`commit-dist.yml`** — triggers on `workflow_run`, so the workflow definition executed here is the trusted copy from `main`. Downloads the artifact, checks out the PR branch, verifies the head SHA has not moved (race guard), drops in the rebuilt `dist/`, and commits/pushes with the default `GITHUB_TOKEN` (`contents: write`).

Only already-built **bytes** cross the privilege boundary — no PR-authored or dependency code executes with a write credential.

## Notes / trade-offs

- Uses the built-in `GITHUB_TOKEN` (no GitHub App to manage). Consequence: the push does **not** re-trigger `check-dist.yml`, so the rebuilt `dist/` is not independently re-verified. The `Verify head is unchanged` guard plus the builder's own byte diff are the integrity checks. Swapping to a short-lived App token would restore automatic re-verification if desired.
- Also corrects two stale comments in `check-dist.yml` that described Dependabot actor-gating which was never actually implemented.
- `workflows: ["Rebuild dist"]` in `commit-dist.yml` must stay in sync with the `name:` of `rebuild-dist.yml`.
