### PR TITLE
ci: download rebuilt dist/ artifact outside the checkout workspace

### DIFF
--- a/.github/workflows/commit-dist.yml
+++ b/.github/workflows/commit-dist.yml
@@ -37,7 +37,10 @@ jobs:
           name: rebuilt-dist
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
-          path: incoming
+          # Download OUTSIDE the checkout workspace: the later actions/checkout
+          # step runs `git clean -ffdx`, which would delete an untracked
+          # `incoming/` dir inside the workspace before we can use it.
+          path: ${{ runner.temp }}/incoming
 
       # No artifact => the builder found dist/ already up to date. Nothing to do.
       # The head-ref/head-sha values come from an artifact produced in the
@@ -46,13 +49,14 @@ jobs:
       - name: Check for artifact
         id: check
         run: |
-          if [ ! -d incoming/dist ] || [ ! -f incoming/dist-meta/head-ref ] || [ ! -f incoming/dist-meta/head-sha ]; then
+          incoming="${{ runner.temp }}/incoming"
+          if [ ! -d "$incoming/dist" ] || [ ! -f "$incoming/dist-meta/head-ref" ] || [ ! -f "$incoming/dist-meta/head-sha" ]; then
             echo "present=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          head_ref="$(head -n1 incoming/dist-meta/head-ref | tr -d '\r\n')"
-          head_sha="$(head -n1 incoming/dist-meta/head-sha | tr -d '\r\n')"
+          head_ref="$(head -n1 "$incoming/dist-meta/head-ref" | tr -d '\r\n')"
+          head_sha="$(head -n1 "$incoming/dist-meta/head-sha" | tr -d '\r\n')"
 
           if ! printf '%s' "$head_sha" | grep -Eq '^[0-9a-f]{40}$'; then
             echo "Invalid head-sha; refusing to proceed." >&2
@@ -89,8 +93,8 @@ jobs:
         if: steps.check.outputs.present == 'true'
         run: |
           rm -rf dist
-          mv incoming/dist dist
-          rm -rf incoming
+          mv "${{ runner.temp }}/incoming/dist" dist
+          rm -rf "${{ runner.temp }}/incoming"
 
       - name: Commit and push
         if: steps.check.outputs.present == 'true'


### PR DESCRIPTION
## What

Fixes the `Commit dist` workflow, which failed on the first real run against a Dependabot PR ([run 29120113703](https://github.com/actions/attest/actions/runs/29120113703/job/86452986836), for #435) with:

```
mv: cannot stat 'incoming/dist': No such file or directory
```

## Root cause

`commit-dist.yml` downloaded the rebuilt `dist/` artifact into `incoming/` **inside** the checkout workspace. The subsequent `actions/checkout` step runs `git clean -ffdx` by default, which deleted the untracked `incoming/` directory before the "Apply rebuilt dist/" step could move it. The "Check for artifact" step passed only because it ran *before* checkout.

## Fix

Download the artifact to `${{ runner.temp }}/incoming`, which lives outside `$GITHUB_WORKSPACE` and is therefore untouched by checkout's clean. Updated the download `path` and the two steps that reference it.

## Testing

To re-verify after merge, trigger a fresh `Rebuild dist` run on a Dependabot production-bump PR (e.g. re-run or push to #435); the resulting `workflow_run` will exercise the corrected `commit-dist.yml`.
