### PR TITLE
Read subjects from GITHUB_ARTIFACTS_LIST

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,8 @@ See [action.yml](action.yml)
     subject-name:
 
     # Path to checksums file containing digest and name of subjects for
-    # attestation. Digest algorithm is inferred from hex length (sha256 for
-    # 64 characters, sha512 for 128 characters). When "push-to-registry" is
-    # true, all checksums must be sha256. Must specify exactly one of
-    # "subject-path", "subject-digest", or "subject-checksums".
+    # attestation. Must specify exactly one of "subject-path", "subject-digest",
+    # or "subject-checksums".
     subject-checksums:
 
     # Path to the JSON-formatted SBOM file (SPDX or CycloneDX) to attest.
@@ -222,11 +220,10 @@ The artifacts list file must be a JSON object with the following shape:
 ```
 
 Each entry must include a `name`, a `digest` in `algorithm:hex` format, and a
-`kind` of either `file` or `oci`. File-kind entries must use `sha256` digests;
-OCI-kind entries may use `sha256`, `sha384`, or `sha512`.
+`kind` of either `file` or `oci`. Both kinds currently require `sha256` digests.
 
 When `push-to-registry` is enabled, the discovered artifacts list must contain
-exactly one subject and it must be an OCI-kind entry with a SHA-256 digest.
+exactly one subject and it must be an OCI-kind entry.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -94,17 +94,18 @@ See [action.yml](action.yml)
 ```yaml
 - uses: actions/attest@v4
   with:
-    # Path to the artifact serving as the subject of the attestation. Must
-    # specify exactly one of "subject-path", "subject-digest", or
-    # "subject-checksums". May contain a glob pattern or list of paths
-    # (total subject count cannot exceed 1024).
-    # When none of these inputs are provided, subjects are automatically
-    # discovered from the runner-provided $GITHUB_ARTIFACTS_LIST file.
+    # Path to the artifact serving as the subject of the attestation. At most
+    # one of "subject-path", "subject-digest", or "subject-checksums" may be
+    # provided. May contain a glob pattern or list of paths (total subject
+    # count cannot exceed 1024).
+    # If none of these inputs are provided, subjects are discovered from the
+    # runner-provided $GITHUB_ARTIFACTS_LIST environment variable.
     subject-path:
 
     # SHA256 digest of the subject for the attestation. Must be in the form
-    # "sha256:hex_digest" (e.g. "sha256:abc123..."). Must specify exactly one
-    # of "subject-path", "subject-digest", or "subject-checksums".
+    # "sha256:hex_digest" (e.g. "sha256:abc123..."). At most one of
+    # "subject-path", "subject-digest", or "subject-checksums" may be provided.
+    # If none are provided, subjects are discovered from $GITHUB_ARTIFACTS_LIST.
     subject-digest:
 
     # Subject name as it should appear in the attestation. Required when
@@ -112,8 +113,9 @@ See [action.yml](action.yml)
     subject-name:
 
     # Path to checksums file containing digest and name of subjects for
-    # attestation. Must specify exactly one of "subject-path", "subject-digest",
-    # or "subject-checksums".
+    # attestation. At most one of "subject-path", "subject-digest", or
+    # "subject-checksums" may be provided. If none are provided, subjects are
+    # discovered from $GITHUB_ARTIFACTS_LIST.
     subject-checksums:
 
     # Path to the JSON-formatted SBOM file (SPDX or CycloneDX) to attest.
@@ -136,10 +138,10 @@ See [action.yml](action.yml)
     # or "predicate" when creating custom attestations.
     predicate-path:
 
-    # Whether to push the attestation to the image registry. Requires a single
-    # fully-qualified OCI subject with a SHA-256 digest, supplied either
-    # explicitly via "subject-name"/"subject-digest" or discovered from the
-    # runner-provided $GITHUB_ARTIFACTS_LIST file. Defaults to false.
+    # Whether to push the attestation to the image registry. Requires that the
+    # resolved subject is a single fully-qualified OCI image reference with a
+    # SHA-256 digest, whether specified explicitly (via any subject input) or
+    # discovered from the runner-provided artifacts list. Defaults to false.
     push-to-registry:
 
     # Whether to create a storage record for the artifact.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ See [action.yml](action.yml)
     # specify exactly one of "subject-path", "subject-digest", or
     # "subject-checksums". May contain a glob pattern or list of paths
     # (total subject count cannot exceed 1024).
+    # When none of these inputs are provided, subjects are automatically
+    # discovered from the runner-provided $GITHUB_ARTIFACTS_LIST file.
     subject-path:
 
     # SHA256 digest of the subject for the attestation. Must be in the form
@@ -110,8 +112,10 @@ See [action.yml](action.yml)
     subject-name:
 
     # Path to checksums file containing digest and name of subjects for
-    # attestation. Must specify exactly one of "subject-path", "subject-digest",
-    # or "subject-checksums".
+    # attestation. Digest algorithm is inferred from hex length (sha256 for
+    # 64 characters, sha512 for 128 characters). When "push-to-registry" is
+    # true, all checksums must be sha256. Must specify exactly one of
+    # "subject-path", "subject-digest", or "subject-checksums".
     subject-checksums:
 
     # Path to the JSON-formatted SBOM file (SPDX or CycloneDX) to attest.
@@ -134,9 +138,10 @@ See [action.yml](action.yml)
     # or "predicate" when creating custom attestations.
     predicate-path:
 
-    # Whether to push the attestation to the image registry. Requires that the
-    # "subject-name" parameter specify the fully-qualified image name and that
-    # the "subject-digest" parameter be specified. Defaults to false.
+    # Whether to push the attestation to the image registry. Requires a single
+    # fully-qualified OCI subject with a SHA-256 digest, supplied either
+    # explicitly via "subject-name"/"subject-digest" or discovered from the
+    # runner-provided $GITHUB_ARTIFACTS_LIST file. Defaults to false.
     push-to-registry:
 
     # Whether to create a storage record for the artifact.
@@ -182,6 +187,46 @@ No more than 1024 subjects can be attested at the same time.
 
 Whether supplied via the `predicate` or `predicatePath` input, the predicate
 string cannot exceed 16MB.
+
+## Automatic Subject Discovery
+
+When none of the explicit subject inputs (`subject-path`, `subject-digest`,
+`subject-checksums`) are provided, the action automatically discovers subjects
+from the runner-provided `$GITHUB_ARTIFACTS_LIST` environment variable. This
+variable is set by the GitHub Actions runner (see
+[actions/runner#4527](https://github.com/actions/runner/pull/4527)) and points
+to a JSON file describing artifacts produced during the workflow.
+
+> [!NOTE]
+> `$GITHUB_ARTIFACTS` is the producer-facing file-command path to which steps
+> append subject declarations; `$GITHUB_ARTIFACTS_LIST` is the runner-generated
+> read-only JSON list consumed by later steps.
+
+Explicit subject inputs always take precedence — when any of `subject-path`,
+`subject-digest`, or `subject-checksums` is provided, the `$GITHUB_ARTIFACTS_LIST`
+file is never read.
+
+The artifacts list file must be a JSON object with the following shape:
+
+```json
+{
+  "version": 1,
+  "subjects": [
+    {
+      "name": "my-binary-linux-amd64",
+      "digest": "sha256:abc123...",
+      "kind": "file"
+    }
+  ]
+}
+```
+
+Each entry must include a `name`, a `digest` in `algorithm:hex` format, and a
+`kind` of either `file` or `oci`. File-kind entries must use `sha256` digests;
+OCI-kind entries may use `sha256`, `sha384`, or `sha512`.
+
+When `push-to-registry` is enabled, the discovered artifacts list must contain
+exactly one subject and it must be an OCI-kind entry with a SHA-256 digest.
 
 ## Examples
 

--- a/__tests__/integration/main.test.ts
+++ b/__tests__/integration/main.test.ts
@@ -450,7 +450,7 @@ describe('run', () => {
       )
     })
 
-    it('should fail when discovered OCI artifact uses sha512 with push-to-registry', async () => {
+    it('should fail when discovered OCI artifact uses sha512 (not allowed)', async () => {
       const listPath = path.join(tempDir, 'artifacts.json')
       await fs.writeFile(
         listPath,
@@ -469,51 +469,15 @@ describe('run', () => {
 
       await run({
         ...defaultInputs,
-        pushToRegistry: true,
         predicateType: 'https://example.com/predicate',
         predicate: '{}'
       })
 
       expect(setFailedMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          message: expect.stringMatching(/push-to-registry.*sha256/)
-        })
-      )
-      expect(mockAttest).not.toHaveBeenCalled()
-    })
-
-    it('should fail when subject-checksums contain sha512 with push-to-registry', async () => {
-      const sha512 = 'a'.repeat(128)
-      await run({
-        ...defaultInputs,
-        subjectChecksums: `${sha512}  artifact-amd64`,
-        pushToRegistry: true,
-        predicateType: 'https://example.com/predicate',
-        predicate: '{}'
-      })
-
-      expect(setFailedMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: expect.stringMatching(/push-to-registry.*sha256/)
-        })
-      )
-      expect(mockAttest).not.toHaveBeenCalled()
-    })
-
-    it('should fail when mixed checksums contain any sha512 with push-to-registry', async () => {
-      const sha256 = 'a'.repeat(64)
-      const sha512 = 'b'.repeat(128)
-      await run({
-        ...defaultInputs,
-        subjectChecksums: `${sha256}  artifact-one\n${sha512}  artifact-two`,
-        pushToRegistry: true,
-        predicateType: 'https://example.com/predicate',
-        predicate: '{}'
-      })
-
-      expect(setFailedMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          message: expect.stringMatching(/push-to-registry.*sha256/)
+          message: expect.stringMatching(
+            /algorithm "sha512" is not allowed for kind "oci"/
+          )
         })
       )
       expect(mockAttest).not.toHaveBeenCalled()
@@ -607,43 +571,6 @@ describe('run', () => {
         })
       )
       expect(mockAttest).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('discovered non-sha256 digest without registry', () => {
-    it('should succeed with discovered sha512 OCI subject when not pushing to registry', async () => {
-      const listPath = path.join(tempDir, 'artifacts.json')
-      await fs.writeFile(
-        listPath,
-        JSON.stringify({
-          version: 1,
-          subjects: [
-            {
-              name: 'ghcr.io/test-owner/test-repo',
-              kind: 'oci',
-              digest: `sha512:${'a'.repeat(128)}`
-            }
-          ]
-        })
-      )
-      process.env.GITHUB_ARTIFACTS_LIST = listPath
-
-      await run({
-        ...defaultInputs,
-        predicateType: 'https://example.com/predicate',
-        predicate: '{}'
-      })
-
-      expect(setFailedMock).not.toHaveBeenCalled()
-      expect(mockAttest).toHaveBeenCalledWith(
-        expect.objectContaining({
-          subjects: [
-            expect.objectContaining({
-              digest: { sha512: 'a'.repeat(128) }
-            })
-          ]
-        })
-      )
     })
   })
 })

--- a/__tests__/integration/main.test.ts
+++ b/__tests__/integration/main.test.ts
@@ -572,5 +572,95 @@ describe('run', () => {
       )
       expect(mockAttest).not.toHaveBeenCalled()
     })
+
+    it('should allow SHA-512 subject-checksums when pushToRegistry is false', async () => {
+      const sha512Digest = 'a'.repeat(128)
+
+      await run({
+        ...defaultInputs,
+        subjectChecksums: `${sha512Digest} my-artifact`,
+        predicateType: 'https://example.com/predicate',
+        predicate: '{}',
+        pushToRegistry: false
+      })
+
+      expect(setFailedMock).not.toHaveBeenCalled()
+      expect(mockAttest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subjects: [
+            expect.objectContaining({
+              name: 'my-artifact',
+              digest: { sha512: sha512Digest }
+            })
+          ]
+        })
+      )
+    })
+
+    it('should fail with SHA-512 subject-checksums when pushToRegistry is true', async () => {
+      const sha512Digest = 'a'.repeat(128)
+
+      await run({
+        ...defaultInputs,
+        subjectChecksums: `${sha512Digest} ghcr.io/owner/repo`,
+        predicateType: 'https://example.com/predicate',
+        predicate: '{}',
+        pushToRegistry: true
+      })
+
+      expect(setFailedMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringMatching(
+            /push-to-registry requires a subject with a SHA-256 digest/
+          )
+        })
+      )
+      expect(mockAttest).not.toHaveBeenCalled()
+    })
+
+    it('should fail when multiple explicit subject-checksums are used with pushToRegistry', async () => {
+      const checksums = [
+        `${'a'.repeat(64)} ghcr.io/owner/app1`,
+        `${'b'.repeat(64)} ghcr.io/owner/app2`
+      ].join('\n')
+
+      await run({
+        ...defaultInputs,
+        subjectChecksums: checksums,
+        predicateType: 'https://example.com/predicate',
+        predicate: '{}',
+        pushToRegistry: true
+      })
+
+      expect(setFailedMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringMatching(
+            /push-to-registry requires exactly one subject but 2 subjects were resolved/
+          )
+        })
+      )
+      expect(mockAttest).not.toHaveBeenCalled()
+    })
+
+    it('should succeed with single SHA-256 explicit subject and pushToRegistry', async () => {
+      await run({
+        ...registryInputs
+      })
+
+      expect(setFailedMock).not.toHaveBeenCalled()
+      expect(mockAttest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subjects: [
+            expect.objectContaining({
+              name: 'ghcr.io/test-owner/test-repo',
+              digest: {
+                sha256:
+                  '7d070f6b64d9bcc530fe99cc21eaaa4b3c364e0b2d367d7735671fa202a03b32'
+              }
+            })
+          ]
+        })
+      )
+    })
   })
 })

--- a/__tests__/integration/main.test.ts
+++ b/__tests__/integration/main.test.ts
@@ -449,5 +449,201 @@ describe('run', () => {
         })
       )
     })
+
+    it('should fail when discovered OCI artifact uses sha512 with push-to-registry', async () => {
+      const listPath = path.join(tempDir, 'artifacts.json')
+      await fs.writeFile(
+        listPath,
+        JSON.stringify({
+          version: 1,
+          subjects: [
+            {
+              name: 'ghcr.io/test-owner/test-repo',
+              kind: 'oci',
+              digest: `sha512:${'a'.repeat(128)}`
+            }
+          ]
+        })
+      )
+      process.env.GITHUB_ARTIFACTS_LIST = listPath
+
+      await run({
+        ...defaultInputs,
+        pushToRegistry: true,
+        predicateType: 'https://example.com/predicate',
+        predicate: '{}'
+      })
+
+      expect(setFailedMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringMatching(/push-to-registry.*sha256/)
+        })
+      )
+      expect(mockAttest).not.toHaveBeenCalled()
+    })
+
+    it('should fail when subject-checksums contain sha512 with push-to-registry', async () => {
+      const sha512 = 'a'.repeat(128)
+      await run({
+        ...defaultInputs,
+        subjectChecksums: `${sha512}  artifact-amd64`,
+        pushToRegistry: true,
+        predicateType: 'https://example.com/predicate',
+        predicate: '{}'
+      })
+
+      expect(setFailedMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringMatching(/push-to-registry.*sha256/)
+        })
+      )
+      expect(mockAttest).not.toHaveBeenCalled()
+    })
+
+    it('should fail when mixed checksums contain any sha512 with push-to-registry', async () => {
+      const sha256 = 'a'.repeat(64)
+      const sha512 = 'b'.repeat(128)
+      await run({
+        ...defaultInputs,
+        subjectChecksums: `${sha256}  artifact-one\n${sha512}  artifact-two`,
+        pushToRegistry: true,
+        predicateType: 'https://example.com/predicate',
+        predicate: '{}'
+      })
+
+      expect(setFailedMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringMatching(/push-to-registry.*sha256/)
+        })
+      )
+      expect(mockAttest).not.toHaveBeenCalled()
+    })
+
+    it('should accept sha256 subject-path with push-to-registry', async () => {
+      const filePath = path.join(tempDir, 'image-artifact.bin')
+      await fs.writeFile(filePath, 'test content')
+
+      await run({
+        ...defaultInputs,
+        subjectPath: filePath,
+        subjectName: 'ghcr.io/test-owner/test-repo',
+        pushToRegistry: true,
+        predicateType: 'https://example.com/predicate',
+        predicate: '{}'
+      })
+
+      expect(setFailedMock).not.toHaveBeenCalled()
+      expect(mockAttest).toHaveBeenCalled()
+    })
+
+    it('should fail when discovered file-kind subject is used with push-to-registry', async () => {
+      const listPath = path.join(tempDir, 'artifacts.json')
+      await fs.writeFile(
+        listPath,
+        JSON.stringify({
+          version: 1,
+          subjects: [
+            {
+              name: 'my-binary',
+              kind: 'file',
+              digest: `sha256:${'a'.repeat(64)}`
+            }
+          ]
+        })
+      )
+      process.env.GITHUB_ARTIFACTS_LIST = listPath
+
+      await run({
+        ...defaultInputs,
+        pushToRegistry: true,
+        predicateType: 'https://example.com/predicate',
+        predicate: '{}'
+      })
+
+      expect(setFailedMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringMatching(
+            /push-to-registry requires an OCI subject/
+          )
+        })
+      )
+      expect(mockAttest).not.toHaveBeenCalled()
+    })
+
+    it('should fail when multiple discovered OCI subjects are used with push-to-registry', async () => {
+      const listPath = path.join(tempDir, 'artifacts.json')
+      await fs.writeFile(
+        listPath,
+        JSON.stringify({
+          version: 1,
+          subjects: [
+            {
+              name: 'ghcr.io/owner/app1',
+              kind: 'oci',
+              digest: `sha256:${'a'.repeat(64)}`
+            },
+            {
+              name: 'ghcr.io/owner/app2',
+              kind: 'oci',
+              digest: `sha256:${'b'.repeat(64)}`
+            }
+          ]
+        })
+      )
+      process.env.GITHUB_ARTIFACTS_LIST = listPath
+
+      await run({
+        ...defaultInputs,
+        pushToRegistry: true,
+        predicateType: 'https://example.com/predicate',
+        predicate: '{}'
+      })
+
+      expect(setFailedMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringMatching(
+            /push-to-registry requires exactly one subject/
+          )
+        })
+      )
+      expect(mockAttest).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('discovered non-sha256 digest without registry', () => {
+    it('should succeed with discovered sha512 OCI subject when not pushing to registry', async () => {
+      const listPath = path.join(tempDir, 'artifacts.json')
+      await fs.writeFile(
+        listPath,
+        JSON.stringify({
+          version: 1,
+          subjects: [
+            {
+              name: 'ghcr.io/test-owner/test-repo',
+              kind: 'oci',
+              digest: `sha512:${'a'.repeat(128)}`
+            }
+          ]
+        })
+      )
+      process.env.GITHUB_ARTIFACTS_LIST = listPath
+
+      await run({
+        ...defaultInputs,
+        predicateType: 'https://example.com/predicate',
+        predicate: '{}'
+      })
+
+      expect(setFailedMock).not.toHaveBeenCalled()
+      expect(mockAttest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subjects: [
+            expect.objectContaining({
+              digest: { sha512: 'a'.repeat(128) }
+            })
+          ]
+        })
+      )
+    })
   })
 })

--- a/__tests__/unit/artifacts.test.ts
+++ b/__tests__/unit/artifacts.test.ts
@@ -1,7 +1,11 @@
 import fs from 'fs/promises'
 import os from 'os'
 import path from 'path'
-import { readArtifactsList, parseArtifactsList } from '../../src/artifacts'
+import {
+  errorMessage,
+  readArtifactsList,
+  parseArtifactsList
+} from '../../src/artifacts'
 
 const ENV_KEY = 'GITHUB_ARTIFACTS_LIST'
 
@@ -826,5 +830,17 @@ describe('parseArtifactsList', () => {
 
       expect(result).toHaveLength(2)
     })
+  })
+})
+
+describe('errorMessage', () => {
+  it('should extract message from Error instances', () => {
+    expect(errorMessage(new Error('boom'))).toBe('boom')
+  })
+
+  it('should stringify non-Error values', () => {
+    expect(errorMessage('raw string')).toBe('raw string')
+    expect(errorMessage(42)).toBe('42')
+    expect(errorMessage(null)).toBe('null')
   })
 })

--- a/__tests__/unit/artifacts.test.ts
+++ b/__tests__/unit/artifacts.test.ts
@@ -1,0 +1,830 @@
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import { readArtifactsList, parseArtifactsList } from '../../src/artifacts'
+
+const ENV_KEY = 'GITHUB_ARTIFACTS_LIST'
+
+describe('readArtifactsList', () => {
+  const originalEnv = process.env
+
+  let tempDir: string
+
+  beforeEach(async () => {
+    process.env = { ...originalEnv }
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'artifacts-test-'))
+  })
+
+  afterEach(async () => {
+    process.env = originalEnv
+    await fs.rm(tempDir, { recursive: true, force: true })
+  })
+
+  describe('env var handling', () => {
+    it('should return undefined when env var is unset', async () => {
+      delete process.env[ENV_KEY]
+      expect(await readArtifactsList()).toBeUndefined()
+    })
+
+    it('should return undefined when env var is empty string', async () => {
+      process.env[ENV_KEY] = ''
+      expect(await readArtifactsList()).toBeUndefined()
+    })
+
+    it('should return undefined when env var is blank/whitespace', async () => {
+      process.env[ENV_KEY] = '   '
+      expect(await readArtifactsList()).toBeUndefined()
+    })
+  })
+
+  describe('file reading', () => {
+    it('should throw when file is unreadable', async () => {
+      process.env[ENV_KEY] = path.join(tempDir, 'nonexistent.json')
+      await expect(readArtifactsList()).rejects.toThrow(
+        /Failed to read artifacts list/
+      )
+    })
+
+    it('should parse valid file content', async () => {
+      const filePath = path.join(tempDir, 'artifacts.json')
+      const data = {
+        version: 1,
+        subjects: [
+          {
+            name: 'my-binary',
+            digest: `sha256:${'a'.repeat(64)}`,
+            kind: 'file'
+          }
+        ]
+      }
+      await fs.writeFile(filePath, JSON.stringify(data))
+      process.env[ENV_KEY] = filePath
+
+      const subjects = await readArtifactsList()
+
+      expect(subjects).toBeDefined()
+      expect(subjects).toHaveLength(1)
+      expect(subjects?.[0].name).toBe('my-binary')
+      expect(subjects?.[0].digest).toEqual({ sha256: 'a'.repeat(64) })
+    })
+  })
+})
+
+describe('parseArtifactsList', () => {
+  describe('structural validation', () => {
+    it('should return empty array on empty string', () => {
+      expect(parseArtifactsList('')).toEqual([])
+    })
+
+    it('should return empty array on whitespace-only content', () => {
+      expect(parseArtifactsList('   \n  ')).toEqual([])
+    })
+
+    it('should throw on UTF-8 BOM', () => {
+      const content = '\uFEFF{"version":1,"subjects":[]}'
+      expect(() => parseArtifactsList(content)).toThrow(
+        /UTF-8 BOM/
+      )
+    })
+
+    it('should throw on invalid JSON', () => {
+      expect(() => parseArtifactsList('{not json}')).toThrow(
+        /invalid JSON/
+      )
+    })
+
+    it('should throw when content is a JSON array', () => {
+      expect(() => parseArtifactsList('[]')).toThrow(
+        /must be a JSON object/
+      )
+    })
+
+    it('should throw when content is a JSON string', () => {
+      expect(() => parseArtifactsList('"hello"')).toThrow(
+        /must be a JSON object/
+      )
+    })
+
+    it('should throw when content is null', () => {
+      expect(() => parseArtifactsList('null')).toThrow(
+        /must be a JSON object/
+      )
+    })
+  })
+
+  describe('version validation', () => {
+    it('should throw for version 0', () => {
+      expect(() =>
+        parseArtifactsList(JSON.stringify({ version: 0, subjects: [] }))
+      ).toThrow(/Unsupported artifacts list version.*0.*expected 1/)
+    })
+
+    it('should throw for version 2', () => {
+      expect(() =>
+        parseArtifactsList(JSON.stringify({ version: 2, subjects: [] }))
+      ).toThrow(/Unsupported artifacts list version.*2.*expected 1/)
+    })
+
+    it('should throw for string version', () => {
+      expect(() =>
+        parseArtifactsList(JSON.stringify({ version: '1', subjects: [] }))
+      ).toThrow(/Unsupported artifacts list version/)
+    })
+
+    it('should throw for missing version', () => {
+      expect(() =>
+        parseArtifactsList(JSON.stringify({ subjects: [] }))
+      ).toThrow(/Unsupported artifacts list version/)
+    })
+  })
+
+  describe('subjects array validation', () => {
+    it('should throw when subjects is missing', () => {
+      expect(() =>
+        parseArtifactsList(JSON.stringify({ version: 1 }))
+      ).toThrow(/missing a "subjects" array/)
+    })
+
+    it('should throw when subjects is not an array', () => {
+      expect(() =>
+        parseArtifactsList(
+          JSON.stringify({ version: 1, subjects: 'not-array' })
+        )
+      ).toThrow(/missing a "subjects" array/)
+    })
+
+    it('should return empty array for empty subjects', () => {
+      const result = parseArtifactsList(
+        JSON.stringify({ version: 1, subjects: [] })
+      )
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('entry validation', () => {
+    const wrap = (subjects: unknown[]): string =>
+      JSON.stringify({ version: 1, subjects })
+
+    it('should throw when entry is not an object', () => {
+      expect(() => parseArtifactsList(wrap(['not-an-object']))).toThrow(
+        /entry 0: must be a JSON object/
+      )
+    })
+
+    it('should throw when entry is an array', () => {
+      expect(() => parseArtifactsList(wrap([[]]))).toThrow(
+        /entry 0: must be a JSON object/
+      )
+    })
+
+    it('should throw when entry is null', () => {
+      expect(() => parseArtifactsList(wrap([null]))).toThrow(
+        /entry 0: must be a JSON object/
+      )
+    })
+
+    describe('name validation', () => {
+      it('should throw when name is missing', () => {
+        expect(() =>
+          parseArtifactsList(
+            wrap([{ kind: 'file', digest: `sha256:${'a'.repeat(64)}` }])
+          )
+        ).toThrow(/entry 0: "name" must be a non-empty string/)
+      })
+
+      it('should throw when name is empty', () => {
+        expect(() =>
+          parseArtifactsList(
+            wrap([
+              { name: '', kind: 'file', digest: `sha256:${'a'.repeat(64)}` }
+            ])
+          )
+        ).toThrow(/entry 0: "name" must be a non-empty string/)
+      })
+
+      it('should throw when name is not a string', () => {
+        expect(() =>
+          parseArtifactsList(
+            wrap([
+              { name: 42, kind: 'file', digest: `sha256:${'a'.repeat(64)}` }
+            ])
+          )
+        ).toThrow(/entry 0: "name" must be a non-empty string/)
+      })
+    })
+
+    describe('kind validation', () => {
+      it('should throw when kind is missing', () => {
+        expect(() =>
+          parseArtifactsList(
+            wrap([{ name: 'a', digest: `sha256:${'a'.repeat(64)}` }])
+          )
+        ).toThrow(/entry 0: "kind" must be a string/)
+      })
+
+      it('should throw for unsupported kind', () => {
+        expect(() =>
+          parseArtifactsList(
+            wrap([
+              {
+                name: 'a',
+                kind: 'npm',
+                digest: `sha256:${'a'.repeat(64)}`
+              }
+            ])
+          )
+        ).toThrow(/entry 0: unsupported kind "npm".*"file" or "oci"/)
+      })
+    })
+
+    describe('digest validation', () => {
+      it('should throw when digest is missing', () => {
+        expect(() =>
+          parseArtifactsList(wrap([{ name: 'a', kind: 'file' }]))
+        ).toThrow(/entry 0: "digest" must be a non-empty string/)
+      })
+
+      it('should throw when digest is empty', () => {
+        expect(() =>
+          parseArtifactsList(
+            wrap([{ name: 'a', kind: 'file', digest: '' }])
+          )
+        ).toThrow(/entry 0: "digest" must be a non-empty string/)
+      })
+
+      it('should throw when digest has no colon', () => {
+        expect(() =>
+          parseArtifactsList(
+            wrap([
+              { name: 'a', kind: 'file', digest: `sha256${'a'.repeat(64)}` }
+            ])
+          )
+        ).toThrow(/entry 0: digest must be in the format "algorithm:hex"/)
+      })
+
+      it('should throw when algorithm is not allowed for kind', () => {
+        expect(() =>
+          parseArtifactsList(
+            wrap([
+              {
+                name: 'a',
+                kind: 'file',
+                digest: `sha512:${'a'.repeat(128)}`
+              }
+            ])
+          )
+        ).toThrow(
+          /entry 0: algorithm "sha512" is not allowed for kind "file"/
+        )
+      })
+
+      it('should throw when hex contains invalid characters', () => {
+        expect(() =>
+          parseArtifactsList(
+            wrap([
+              {
+                name: 'a',
+                kind: 'file',
+                digest: `sha256:${'g'.repeat(64)}`
+              }
+            ])
+          )
+        ).toThrow(/entry 0: digest contains invalid hex characters/)
+      })
+
+      it('should throw when hex has wrong length', () => {
+        expect(() =>
+          parseArtifactsList(
+            wrap([
+              { name: 'a', kind: 'file', digest: 'sha256:abcd' }
+            ])
+          )
+        ).toThrow(
+          /entry 0: digest has 4 hex characters but "sha256" requires exactly 64/
+        )
+      })
+    })
+  })
+
+  describe('kind-specific algorithm rules', () => {
+    const wrap = (subjects: unknown[]): string =>
+      JSON.stringify({ version: 1, subjects })
+
+    describe('file kind', () => {
+      it('should accept sha256 (64 hex chars)', () => {
+        const result = parseArtifactsList(
+          wrap([
+            {
+              name: 'binary',
+              kind: 'file',
+              digest: `sha256:${'a'.repeat(64)}`
+            }
+          ])
+        )
+        expect(result).toHaveLength(1)
+        expect(result[0].digest).toEqual({ sha256: 'a'.repeat(64) })
+      })
+
+      it('should reject sha384 for file kind', () => {
+        expect(() =>
+          parseArtifactsList(
+            wrap([
+              {
+                name: 'binary',
+                kind: 'file',
+                digest: `sha384:${'a'.repeat(96)}`
+              }
+            ])
+          )
+        ).toThrow(/algorithm "sha384" is not allowed for kind "file"/)
+      })
+
+      it('should reject sha512 for file kind', () => {
+        expect(() =>
+          parseArtifactsList(
+            wrap([
+              {
+                name: 'binary',
+                kind: 'file',
+                digest: `sha512:${'a'.repeat(128)}`
+              }
+            ])
+          )
+        ).toThrow(/algorithm "sha512" is not allowed for kind "file"/)
+      })
+    })
+
+    describe('oci kind', () => {
+      it('should accept sha256 (64 hex chars)', () => {
+        const result = parseArtifactsList(
+          wrap([
+            {
+              name: 'ghcr.io/owner/image',
+              kind: 'oci',
+              digest: `sha256:${'b'.repeat(64)}`
+            }
+          ])
+        )
+        expect(result).toHaveLength(1)
+        expect(result[0].digest).toEqual({ sha256: 'b'.repeat(64) })
+      })
+
+      it('should accept sha384 (96 hex chars)', () => {
+        const result = parseArtifactsList(
+          wrap([
+            {
+              name: 'ghcr.io/owner/image',
+              kind: 'oci',
+              digest: `sha384:${'c'.repeat(96)}`
+            }
+          ])
+        )
+        expect(result).toHaveLength(1)
+        expect(result[0].digest).toEqual({ sha384: 'c'.repeat(96) })
+      })
+
+      it('should accept sha512 (128 hex chars)', () => {
+        const result = parseArtifactsList(
+          wrap([
+            {
+              name: 'ghcr.io/owner/image',
+              kind: 'oci',
+              digest: `sha512:${'d'.repeat(128)}`
+            }
+          ])
+        )
+        expect(result).toHaveLength(1)
+        expect(result[0].digest).toEqual({ sha512: 'd'.repeat(128) })
+      })
+    })
+  })
+
+  describe('valid entries', () => {
+    const wrap = (subjects: unknown[]): string =>
+      JSON.stringify({ version: 1, subjects })
+
+    it('should parse a single file entry', () => {
+      const result = parseArtifactsList(
+        wrap([
+          {
+            name: 'my-binary-linux-amd64',
+            kind: 'file',
+            digest: `sha256:${'ab'.repeat(32)}`
+          }
+        ])
+      )
+
+      expect(result).toEqual([
+        {
+          name: 'my-binary-linux-amd64',
+          digest: { sha256: 'ab'.repeat(32) }
+        }
+      ])
+    })
+
+    it('should parse a single OCI entry', () => {
+      const result = parseArtifactsList(
+        wrap([
+          {
+            name: 'ghcr.io/owner/app',
+            kind: 'oci',
+            digest: `sha256:${'cd'.repeat(32)}`
+          }
+        ])
+      )
+
+      expect(result).toEqual([
+        {
+          name: 'ghcr.io/owner/app',
+          digest: { sha256: 'cd'.repeat(32) }
+        }
+      ])
+    })
+
+    it('should parse multiple mixed entries', () => {
+      const result = parseArtifactsList(
+        wrap([
+          {
+            name: 'binary-linux',
+            kind: 'file',
+            digest: `sha256:${'a'.repeat(64)}`
+          },
+          {
+            name: 'binary-darwin',
+            kind: 'file',
+            digest: `sha256:${'b'.repeat(64)}`
+          },
+          {
+            name: 'ghcr.io/owner/app',
+            kind: 'oci',
+            digest: `sha512:${'c'.repeat(128)}`
+          }
+        ])
+      )
+
+      expect(result).toHaveLength(3)
+      expect(result[0].name).toBe('binary-linux')
+      expect(result[1].name).toBe('binary-darwin')
+      expect(result[2].name).toBe('ghcr.io/owner/app')
+    })
+
+    it('should accept uppercase hex characters', () => {
+      const result = parseArtifactsList(
+        wrap([
+          {
+            name: 'binary',
+            kind: 'file',
+            digest: `sha256:${'ABCDEF01'.repeat(8)}`
+          }
+        ])
+      )
+
+      expect(result).toHaveLength(1)
+      expect(result[0].digest).toEqual({ sha256: 'ABCDEF01'.repeat(8) })
+    })
+  })
+
+  describe('deduplication and conflicts', () => {
+    const wrap = (subjects: unknown[]): string =>
+      JSON.stringify({ version: 1, subjects })
+
+    it('should deduplicate exact (name, kind, digest) duplicates', () => {
+      const entry = {
+        name: 'my-binary',
+        kind: 'file',
+        digest: `sha256:${'a'.repeat(64)}`
+      }
+
+      const result = parseArtifactsList(wrap([entry, entry]))
+
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('my-binary')
+    })
+
+    it('should preserve runner order after dedup', () => {
+      const result = parseArtifactsList(
+        wrap([
+          {
+            name: 'second',
+            kind: 'file',
+            digest: `sha256:${'b'.repeat(64)}`
+          },
+          {
+            name: 'first',
+            kind: 'file',
+            digest: `sha256:${'a'.repeat(64)}`
+          },
+          {
+            name: 'second',
+            kind: 'file',
+            digest: `sha256:${'b'.repeat(64)}`
+          }
+        ])
+      )
+
+      expect(result).toHaveLength(2)
+      expect(result[0].name).toBe('second')
+      expect(result[1].name).toBe('first')
+    })
+
+    it('should throw on conflicting digest for same name', () => {
+      expect(() =>
+        parseArtifactsList(
+          wrap([
+            {
+              name: 'my-binary',
+              kind: 'file',
+              digest: `sha256:${'a'.repeat(64)}`
+            },
+            {
+              name: 'my-binary',
+              kind: 'file',
+              digest: `sha256:${'b'.repeat(64)}`
+            }
+          ])
+        )
+      ).toThrow(
+        /entry 1: duplicate name "my-binary" with conflicting kind or digest/
+      )
+    })
+
+    it('should throw on conflicting kind for same name', () => {
+      expect(() =>
+        parseArtifactsList(
+          wrap([
+            {
+              name: 'my-artifact',
+              kind: 'file',
+              digest: `sha256:${'a'.repeat(64)}`
+            },
+            {
+              name: 'my-artifact',
+              kind: 'oci',
+              digest: `sha256:${'a'.repeat(64)}`
+            }
+          ])
+        )
+      ).toThrow(
+        /entry 1: duplicate name "my-artifact" with conflicting kind or digest/
+      )
+    })
+  })
+
+  describe('downcaseOCI option', () => {
+    const wrap = (subjects: unknown[]): string =>
+      JSON.stringify({ version: 1, subjects })
+
+    it('should lowercase OCI names when downcaseOCI is true', () => {
+      const result = parseArtifactsList(
+        wrap([
+          {
+            name: 'ghcr.io/Owner/My-Image',
+            kind: 'oci',
+            digest: `sha256:${'a'.repeat(64)}`
+          }
+        ]),
+        { downcaseOCI: true }
+      )
+
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('ghcr.io/owner/my-image')
+    })
+
+    it('should NOT lowercase file names when downcaseOCI is true', () => {
+      const result = parseArtifactsList(
+        wrap([
+          {
+            name: 'My-Binary-Linux',
+            kind: 'file',
+            digest: `sha256:${'b'.repeat(64)}`
+          }
+        ]),
+        { downcaseOCI: true }
+      )
+
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('My-Binary-Linux')
+    })
+
+    it('should lowercase OCI but not file in mixed list', () => {
+      const result = parseArtifactsList(
+        wrap([
+          {
+            name: 'My-Binary',
+            kind: 'file',
+            digest: `sha256:${'a'.repeat(64)}`
+          },
+          {
+            name: 'ghcr.io/Owner/APP',
+            kind: 'oci',
+            digest: `sha256:${'b'.repeat(64)}`
+          }
+        ]),
+        { downcaseOCI: true }
+      )
+
+      expect(result).toHaveLength(2)
+      expect(result[0].name).toBe('My-Binary')
+      expect(result[1].name).toBe('ghcr.io/owner/app')
+    })
+
+    it('should NOT lowercase OCI names when downcaseOCI is false', () => {
+      const result = parseArtifactsList(
+        wrap([
+          {
+            name: 'ghcr.io/Owner/My-Image',
+            kind: 'oci',
+            digest: `sha256:${'a'.repeat(64)}`
+          }
+        ]),
+        { downcaseOCI: false }
+      )
+
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('ghcr.io/Owner/My-Image')
+    })
+
+    it('should NOT lowercase OCI names when options are omitted', () => {
+      const result = parseArtifactsList(
+        wrap([
+          {
+            name: 'ghcr.io/Owner/My-Image',
+            kind: 'oci',
+            digest: `sha256:${'a'.repeat(64)}`
+          }
+        ])
+      )
+
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('ghcr.io/Owner/My-Image')
+    })
+
+    it('should deduplicate case-only duplicate OCI names after normalization', () => {
+      const result = parseArtifactsList(
+        wrap([
+          {
+            name: 'ghcr.io/Owner/APP',
+            kind: 'oci',
+            digest: `sha256:${'a'.repeat(64)}`
+          },
+          {
+            name: 'ghcr.io/owner/app',
+            kind: 'oci',
+            digest: `sha256:${'a'.repeat(64)}`
+          }
+        ]),
+        { downcaseOCI: true }
+      )
+
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('ghcr.io/owner/app')
+    })
+
+    it('should reject case-colliding OCI names with conflicting digest after normalization', () => {
+      expect(() =>
+        parseArtifactsList(
+          wrap([
+            {
+              name: 'ghcr.io/Owner/APP',
+              kind: 'oci',
+              digest: `sha256:${'a'.repeat(64)}`
+            },
+            {
+              name: 'ghcr.io/owner/app',
+              kind: 'oci',
+              digest: `sha256:${'b'.repeat(64)}`
+            }
+          ]),
+          { downcaseOCI: true }
+        )
+      ).toThrow(
+        /entry 1: duplicate name "ghcr.io\/owner\/app" with conflicting kind or digest/
+      )
+    })
+  })
+
+  describe('requireSingleOCI option', () => {
+    const wrap = (subjects: unknown[]): string =>
+      JSON.stringify({ version: 1, subjects })
+
+    it('should accept a single OCI subject', () => {
+      const result = parseArtifactsList(
+        wrap([
+          {
+            name: 'ghcr.io/owner/app',
+            kind: 'oci',
+            digest: `sha256:${'a'.repeat(64)}`
+          }
+        ]),
+        { requireSingleOCI: true }
+      )
+
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('ghcr.io/owner/app')
+    })
+
+    it('should reject when discovered subjects contain file-kind entries', () => {
+      expect(() =>
+        parseArtifactsList(
+          wrap([
+            {
+              name: 'my-binary',
+              kind: 'file',
+              digest: `sha256:${'a'.repeat(64)}`
+            }
+          ]),
+          { requireSingleOCI: true }
+        )
+      ).toThrow(
+        /push-to-registry requires an OCI subject but the discovered artifacts list contains file-kind subjects/
+      )
+    })
+
+    it('should reject when discovered subjects include a mix of file and OCI', () => {
+      expect(() =>
+        parseArtifactsList(
+          wrap([
+            {
+              name: 'ghcr.io/owner/app',
+              kind: 'oci',
+              digest: `sha256:${'a'.repeat(64)}`
+            },
+            {
+              name: 'my-binary',
+              kind: 'file',
+              digest: `sha256:${'b'.repeat(64)}`
+            }
+          ]),
+          { requireSingleOCI: true }
+        )
+      ).toThrow(
+        /push-to-registry requires an OCI subject but the discovered artifacts list contains file-kind subjects/
+      )
+    })
+
+    it('should reject multiple OCI subjects', () => {
+      expect(() =>
+        parseArtifactsList(
+          wrap([
+            {
+              name: 'ghcr.io/owner/app1',
+              kind: 'oci',
+              digest: `sha256:${'a'.repeat(64)}`
+            },
+            {
+              name: 'ghcr.io/owner/app2',
+              kind: 'oci',
+              digest: `sha256:${'b'.repeat(64)}`
+            }
+          ]),
+          { requireSingleOCI: true }
+        )
+      ).toThrow(
+        /push-to-registry requires exactly one subject but the discovered artifacts list contains multiple subjects/
+      )
+    })
+
+    it('should allow empty subjects (no-op for empty list)', () => {
+      const result = parseArtifactsList(
+        wrap([]),
+        { requireSingleOCI: true }
+      )
+
+      expect(result).toEqual([])
+    })
+
+    it('should not enforce requireSingleOCI when option is false', () => {
+      const result = parseArtifactsList(
+        wrap([
+          {
+            name: 'my-binary',
+            kind: 'file',
+            digest: `sha256:${'a'.repeat(64)}`
+          }
+        ]),
+        { requireSingleOCI: false }
+      )
+
+      expect(result).toHaveLength(1)
+    })
+
+    it('should not enforce requireSingleOCI when options are omitted', () => {
+      const result = parseArtifactsList(
+        wrap([
+          {
+            name: 'my-binary',
+            kind: 'file',
+            digest: `sha256:${'a'.repeat(64)}`
+          },
+          {
+            name: 'other-binary',
+            kind: 'file',
+            digest: `sha256:${'b'.repeat(64)}`
+          }
+        ])
+      )
+
+      expect(result).toHaveLength(2)
+    })
+  })
+})

--- a/__tests__/unit/artifacts.test.ts
+++ b/__tests__/unit/artifacts.test.ts
@@ -369,32 +369,32 @@ describe('parseArtifactsList', () => {
         expect(result[0].digest).toEqual({ sha256: 'b'.repeat(64) })
       })
 
-      it('should accept sha384 (96 hex chars)', () => {
-        const result = parseArtifactsList(
-          wrap([
-            {
-              name: 'ghcr.io/owner/image',
-              kind: 'oci',
-              digest: `sha384:${'c'.repeat(96)}`
-            }
-          ])
-        )
-        expect(result).toHaveLength(1)
-        expect(result[0].digest).toEqual({ sha384: 'c'.repeat(96) })
+      it('should reject sha384 for oci kind', () => {
+        expect(() =>
+          parseArtifactsList(
+            wrap([
+              {
+                name: 'ghcr.io/owner/image',
+                kind: 'oci',
+                digest: `sha384:${'c'.repeat(96)}`
+              }
+            ])
+          )
+        ).toThrow(/algorithm "sha384" is not allowed for kind "oci"/)
       })
 
-      it('should accept sha512 (128 hex chars)', () => {
-        const result = parseArtifactsList(
-          wrap([
-            {
-              name: 'ghcr.io/owner/image',
-              kind: 'oci',
-              digest: `sha512:${'d'.repeat(128)}`
-            }
-          ])
-        )
-        expect(result).toHaveLength(1)
-        expect(result[0].digest).toEqual({ sha512: 'd'.repeat(128) })
+      it('should reject sha512 for oci kind', () => {
+        expect(() =>
+          parseArtifactsList(
+            wrap([
+              {
+                name: 'ghcr.io/owner/image',
+                kind: 'oci',
+                digest: `sha512:${'d'.repeat(128)}`
+              }
+            ])
+          )
+        ).toThrow(/algorithm "sha512" is not allowed for kind "oci"/)
       })
     })
   })
@@ -457,7 +457,7 @@ describe('parseArtifactsList', () => {
           {
             name: 'ghcr.io/owner/app',
             kind: 'oci',
-            digest: `sha512:${'c'.repeat(128)}`
+            digest: `sha256:${'c'.repeat(64)}`
           }
         ])
       )

--- a/__tests__/unit/subject.test.ts
+++ b/__tests__/unit/subject.test.ts
@@ -55,6 +55,250 @@ describe('subjectFromInputs', () => {
     })
   })
 
+  describe('artifacts list fallback', () => {
+    const ENV_KEY = 'GITHUB_ARTIFACTS_LIST'
+    const originalEnv = process.env
+
+    beforeEach(() => {
+      process.env = { ...originalEnv }
+    })
+
+    afterEach(() => {
+      process.env = originalEnv
+    })
+
+    it('should use artifacts list when no explicit inputs are provided', async () => {
+      const filePath = path.join(tempDir, 'artifacts.json')
+      await fs.writeFile(
+        filePath,
+        JSON.stringify({
+          version: 1,
+          subjects: [
+            {
+              name: 'discovered-binary',
+              kind: 'file',
+              digest: `sha256:${'a'.repeat(64)}`
+            }
+          ]
+        })
+      )
+      process.env[ENV_KEY] = filePath
+
+      const subjects = await subjectFromInputs(blankInputs)
+
+      expect(subjects).toHaveLength(1)
+      expect(subjects[0].name).toBe('discovered-binary')
+    })
+
+    it('should lowercase discovered OCI names when downcaseName is true', async () => {
+      const filePath = path.join(tempDir, 'artifacts.json')
+      await fs.writeFile(
+        filePath,
+        JSON.stringify({
+          version: 1,
+          subjects: [
+            {
+              name: 'ghcr.io/Owner/My-Image',
+              kind: 'oci',
+              digest: `sha256:${'a'.repeat(64)}`
+            }
+          ]
+        })
+      )
+      process.env[ENV_KEY] = filePath
+
+      const subjects = await subjectFromInputs({
+        ...blankInputs,
+        downcaseName: true
+      })
+
+      expect(subjects).toHaveLength(1)
+      expect(subjects[0].name).toBe('ghcr.io/owner/my-image')
+    })
+
+    it('should reject discovered file-kind subjects when downcaseName is true (registry push)', async () => {
+      const filePath = path.join(tempDir, 'artifacts.json')
+      await fs.writeFile(
+        filePath,
+        JSON.stringify({
+          version: 1,
+          subjects: [
+            {
+              name: 'My-Binary-Linux',
+              kind: 'file',
+              digest: `sha256:${'a'.repeat(64)}`
+            }
+          ]
+        })
+      )
+      process.env[ENV_KEY] = filePath
+
+      await expect(
+        subjectFromInputs({
+          ...blankInputs,
+          downcaseName: true
+        })
+      ).rejects.toThrow(
+        /push-to-registry requires an OCI subject/
+      )
+    })
+
+    it('should preserve file names for discovered file-kind subjects without registry push', async () => {
+      const filePath = path.join(tempDir, 'artifacts.json')
+      await fs.writeFile(
+        filePath,
+        JSON.stringify({
+          version: 1,
+          subjects: [
+            {
+              name: 'My-Binary-Linux',
+              kind: 'file',
+              digest: `sha256:${'a'.repeat(64)}`
+            }
+          ]
+        })
+      )
+      process.env[ENV_KEY] = filePath
+
+      const subjects = await subjectFromInputs({
+        ...blankInputs,
+        downcaseName: false
+      })
+
+      expect(subjects).toHaveLength(1)
+      expect(subjects[0].name).toBe('My-Binary-Linux')
+    })
+
+    it('should throw standard error when env is unset and no explicit inputs', async () => {
+      delete process.env[ENV_KEY]
+
+      await expect(subjectFromInputs(blankInputs)).rejects.toThrow(
+        /one of subject-path, subject-digest, or subject-checksums must be provided/i
+      )
+    })
+
+    it('should throw standard error when artifacts list file is zero-byte', async () => {
+      const filePath = path.join(tempDir, 'zero-byte.json')
+      await fs.writeFile(filePath, '')
+      process.env[ENV_KEY] = filePath
+
+      await expect(subjectFromInputs(blankInputs)).rejects.toThrow(
+        /one of subject-path, subject-digest, or subject-checksums must be provided/i
+      )
+    })
+
+    it('should throw standard error when artifacts list is empty', async () => {
+      const filePath = path.join(tempDir, 'empty.json')
+      await fs.writeFile(
+        filePath,
+        JSON.stringify({ version: 1, subjects: [] })
+      )
+      process.env[ENV_KEY] = filePath
+
+      await expect(subjectFromInputs(blankInputs)).rejects.toThrow(
+        /one of subject-path, subject-digest, or subject-checksums must be provided/i
+      )
+    })
+
+    it('should ignore artifacts list when subject-digest is provided', async () => {
+      const filePath = path.join(tempDir, 'artifacts.json')
+      await fs.writeFile(
+        filePath,
+        JSON.stringify({
+          version: 1,
+          subjects: [
+            {
+              name: 'should-not-appear',
+              kind: 'file',
+              digest: `sha256:${'f'.repeat(64)}`
+            }
+          ]
+        })
+      )
+      process.env[ENV_KEY] = filePath
+
+      const inputs: SubjectInputs = {
+        ...blankInputs,
+        subjectName: 'explicit-artifact',
+        subjectDigest: `sha256:${'a'.repeat(64)}`
+      }
+
+      const subjects = await subjectFromInputs(inputs)
+
+      expect(subjects).toHaveLength(1)
+      expect(subjects[0].name).toBe('explicit-artifact')
+    })
+
+    it('should ignore artifacts list when subject-path is provided', async () => {
+      const artifactFile = path.join(tempDir, 'real-artifact.bin')
+      await fs.writeFile(artifactFile, 'content')
+
+      const listPath = path.join(tempDir, 'artifacts.json')
+      await fs.writeFile(
+        listPath,
+        JSON.stringify({
+          version: 1,
+          subjects: [
+            {
+              name: 'should-not-appear',
+              kind: 'file',
+              digest: `sha256:${'f'.repeat(64)}`
+            }
+          ]
+        })
+      )
+      process.env[ENV_KEY] = listPath
+
+      const inputs: SubjectInputs = {
+        ...blankInputs,
+        subjectPath: artifactFile
+      }
+
+      const subjects = await subjectFromInputs(inputs)
+
+      expect(subjects).toHaveLength(1)
+      expect(subjects[0].name).toBe('real-artifact.bin')
+    })
+
+    it('should ignore artifacts list when subject-checksums is provided', async () => {
+      const listPath = path.join(tempDir, 'artifacts.json')
+      await fs.writeFile(
+        listPath,
+        JSON.stringify({
+          version: 1,
+          subjects: [
+            {
+              name: 'should-not-appear',
+              kind: 'file',
+              digest: `sha256:${'f'.repeat(64)}`
+            }
+          ]
+        })
+      )
+      process.env[ENV_KEY] = listPath
+
+      const inputs: SubjectInputs = {
+        ...blankInputs,
+        subjectChecksums: `${'a'.repeat(64)}  explicit-checksums-artifact`
+      }
+
+      const subjects = await subjectFromInputs(inputs)
+
+      expect(subjects).toHaveLength(1)
+      expect(subjects[0].name).toBe('explicit-checksums-artifact')
+    })
+
+    it('should propagate parse errors from malformed artifacts list', async () => {
+      const filePath = path.join(tempDir, 'bad.json')
+      await fs.writeFile(filePath, '{bad json}')
+      process.env[ENV_KEY] = filePath
+
+      await expect(subjectFromInputs(blankInputs)).rejects.toThrow(
+        /invalid JSON/
+      )
+    })
+  })
+
   describe('with subject-digest', () => {
     const validDigest = 'sha256:7d070f6b64d9bcc530fe99cc21eaaa4b3c364e0b2d367d7735671fa202a03b32'
 

--- a/__tests__/unit/subject.test.ts
+++ b/__tests__/unit/subject.test.ts
@@ -366,6 +366,31 @@ describe('subjectFromInputs', () => {
         /subject-digest must be in the format/
       )
     })
+
+    it('should throw for non-hex characters in digest', async () => {
+      const inputs: SubjectInputs = {
+        ...blankInputs,
+        subjectName: 'artifact',
+        subjectDigest: `sha256:${'g'.repeat(64)}`
+      }
+
+      await expect(subjectFromInputs(inputs)).rejects.toThrow(
+        /subject-digest must be in the format/
+      )
+    })
+
+    it('should accept valid uppercase hex digest', async () => {
+      const inputs: SubjectInputs = {
+        ...blankInputs,
+        subjectName: 'artifact',
+        subjectDigest: `sha256:${'A'.repeat(64)}`
+      }
+
+      const subjects = await subjectFromInputs(inputs)
+
+      expect(subjects).toHaveLength(1)
+      expect(subjects[0].digest).toEqual({ sha256: 'A'.repeat(64) })
+    })
   })
 
   describe('with subject-path', () => {

--- a/__tests__/unit/subject.test.ts
+++ b/__tests__/unit/subject.test.ts
@@ -90,6 +90,21 @@ describe('subjectFromInputs', () => {
       expect(subjects[0].name).toBe('discovered-binary')
     })
 
+    it('should throw when discovered subjects exceed the maximum count', async () => {
+      const filePath = path.join(tempDir, 'artifacts.json')
+      const subjects = Array.from({ length: 1025 }, (_, i) => ({
+        name: `discovered-binary-${i}`,
+        kind: 'file',
+        digest: `sha256:${'a'.repeat(64)}`
+      }))
+      await fs.writeFile(filePath, JSON.stringify({ version: 1, subjects }))
+      process.env[ENV_KEY] = filePath
+
+      await expect(subjectFromInputs(blankInputs)).rejects.toThrow(
+        /too many subjects/i
+      )
+    })
+
     it('should lowercase discovered OCI names when downcaseName is true', async () => {
       const filePath = path.join(tempDir, 'artifacts.json')
       await fs.writeFile(

--- a/__tests__/unit/validate-registry-subjects.test.ts
+++ b/__tests__/unit/validate-registry-subjects.test.ts
@@ -1,0 +1,65 @@
+import { validateRegistrySubjects } from '../../src/main'
+
+import type { Subject } from '@actions/attest'
+
+describe('validateRegistrySubjects', () => {
+  it('should pass for a single subject with SHA-256 digest', () => {
+    const subjects: Subject[] = [
+      {
+        name: 'ghcr.io/owner/repo',
+        digest: { sha256: 'a'.repeat(64) }
+      }
+    ]
+
+    expect(() => validateRegistrySubjects(subjects)).not.toThrow()
+  })
+
+  it('should fail when no subjects are provided', () => {
+    expect(() => validateRegistrySubjects([])).toThrow(
+      /push-to-registry requires exactly one subject but 0 subjects were resolved/
+    )
+  })
+
+  it('should fail when multiple subjects are provided', () => {
+    const subjects: Subject[] = [
+      {
+        name: 'ghcr.io/owner/app1',
+        digest: { sha256: 'a'.repeat(64) }
+      },
+      {
+        name: 'ghcr.io/owner/app2',
+        digest: { sha256: 'b'.repeat(64) }
+      }
+    ]
+
+    expect(() => validateRegistrySubjects(subjects)).toThrow(
+      /push-to-registry requires exactly one subject but 2 subjects were resolved/
+    )
+  })
+
+  it('should fail when subject has SHA-512 digest', () => {
+    const subjects: Subject[] = [
+      {
+        name: 'ghcr.io/owner/repo',
+        digest: { sha512: 'a'.repeat(128) }
+      }
+    ]
+
+    expect(() => validateRegistrySubjects(subjects)).toThrow(
+      /push-to-registry requires a subject with a SHA-256 digest/
+    )
+  })
+
+  it('should fail when subject has both SHA-256 and SHA-512 digests', () => {
+    const subjects: Subject[] = [
+      {
+        name: 'ghcr.io/owner/repo',
+        digest: { sha256: 'a'.repeat(64), sha512: 'b'.repeat(128) }
+      }
+    ]
+
+    expect(() => validateRegistrySubjects(subjects)).toThrow(
+      /push-to-registry requires a subject with a SHA-256 digest/
+    )
+  })
+})

--- a/__tests__/unit/validate-registry-subjects.test.ts
+++ b/__tests__/unit/validate-registry-subjects.test.ts
@@ -1,6 +1,25 @@
-import { validateRegistrySubjects } from '../../src/main'
+import { jest } from '@jest/globals'
 
 import type { Subject } from '@actions/attest'
+
+// src/main pulls in ESM-only dependencies (e.g. @actions/attest, @sigstore/oci)
+// which, when statically imported, load asynchronously under Jest's
+// experimental VM modules. On Node < 24.9 that async import resolves after the
+// test environment is torn down and crashes the suite. Mock those modules and
+// import main dynamically so the heavy graph never loads.
+jest.unstable_mockModule('@actions/core', () => ({}))
+jest.unstable_mockModule('@actions/github', () => ({ context: {} }))
+jest.unstable_mockModule('@actions/attest', () => ({
+  attest: jest.fn(),
+  buildSLSAProvenancePredicate: jest.fn(),
+  createStorageRecord: jest.fn()
+}))
+jest.unstable_mockModule('@sigstore/oci', () => ({
+  getRegistryCredentials: jest.fn(),
+  attachArtifactToImage: jest.fn()
+}))
+
+const { validateRegistrySubjects } = await import('../../src/main')
 
 describe('validateRegistrySubjects', () => {
   it('should pass for a single subject with SHA-256 digest', () => {

--- a/action.yml
+++ b/action.yml
@@ -29,10 +29,8 @@ inputs:
   subject-checksums:
     description: >
       Path to checksums file containing digest and name of subjects for
-      attestation. Digest algorithm is inferred from hex length (sha256 for 64
-      characters, sha512 for 128 characters). When "push-to-registry" is true,
-      all checksums must be sha256. Must specify exactly one of "subject-path",
-      "subject-digest", or "subject-checksums".
+      attestation. Must specify exactly one of "subject-path", "subject-digest",
+      or "subject-checksums".
     required: false
   subject-version:
     description: >

--- a/action.yml
+++ b/action.yml
@@ -9,9 +9,11 @@ inputs:
   subject-path:
     description: >
       Path to the artifact serving as the subject of the attestation. Must
-      specify exactly one of "subject-path",  "subject-digest", or
+      specify exactly one of "subject-path", "subject-digest", or
       "subject-checksums". May contain a glob pattern or list of paths (total
-      subject count cannot exceed 1024).
+      subject count cannot exceed 1024). When none of these inputs are
+      provided, the action falls back to subjects discovered via the
+      runner-provided $GITHUB_ARTIFACTS_LIST environment variable.
     required: false
   subject-digest:
     description: >
@@ -27,8 +29,10 @@ inputs:
   subject-checksums:
     description: >
       Path to checksums file containing digest and name of subjects for
-      attestation. Must specify exactly one of "subject-path", "subject-digest",
-      or "subject-checksums".
+      attestation. Digest algorithm is inferred from hex length (sha256 for 64
+      characters, sha512 for 128 characters). When "push-to-registry" is true,
+      all checksums must be sha256. Must specify exactly one of "subject-path",
+      "subject-digest", or "subject-checksums".
     required: false
   subject-version:
     description: >
@@ -61,9 +65,10 @@ inputs:
     required: false
   push-to-registry:
     description: >
-      Whether to push the attestation to the image registry. Requires that the
-      "subject-name" parameter specify the fully-qualified image name and that
-      the "subject-digest" parameter be specified. Defaults to false.
+      Whether to push the attestation to the image registry. Requires a single
+      fully-qualified OCI subject with a SHA-256 digest, supplied either
+      explicitly via "subject-name"/"subject-digest" or discovered from the
+      runner-provided artifacts list. Defaults to false.
     default: false
     required: false
   create-storage-record:

--- a/action.yml
+++ b/action.yml
@@ -8,18 +8,20 @@ branding:
 inputs:
   subject-path:
     description: >
-      Path to the artifact serving as the subject of the attestation. Must
-      specify exactly one of "subject-path", "subject-digest", or
-      "subject-checksums". May contain a glob pattern or list of paths (total
-      subject count cannot exceed 1024). When none of these inputs are
-      provided, the action falls back to subjects discovered via the
-      runner-provided $GITHUB_ARTIFACTS_LIST environment variable.
+      Path to the artifact serving as the subject of the attestation. At most
+      one of "subject-path", "subject-digest", or "subject-checksums" may be
+      provided. May contain a glob pattern or list of paths (total subject
+      count cannot exceed 1024). If none of these inputs are provided, subjects
+      are discovered from the runner-provided $GITHUB_ARTIFACTS_LIST
+      environment variable.
     required: false
   subject-digest:
     description: >
       Digest of the subject for the attestation. Must be in the form
-      "algorithm:hex_digest" (e.g. "sha256:abc123..."). Must specify exactly one
-      of "subject-path", "subject-digest", or "subject-checksums".
+      "algorithm:hex_digest" (e.g. "sha256:abc123..."). At most one of
+      "subject-path", "subject-digest", or "subject-checksums" may be provided.
+      If none are provided, subjects are discovered from
+      $GITHUB_ARTIFACTS_LIST.
     required: false
   subject-name:
     description: >
@@ -29,8 +31,9 @@ inputs:
   subject-checksums:
     description: >
       Path to checksums file containing digest and name of subjects for
-      attestation. Must specify exactly one of "subject-path", "subject-digest",
-      or "subject-checksums".
+      attestation. At most one of "subject-path", "subject-digest", or
+      "subject-checksums" may be provided. If none are provided, subjects are
+      discovered from $GITHUB_ARTIFACTS_LIST.
     required: false
   subject-version:
     description: >
@@ -63,10 +66,10 @@ inputs:
     required: false
   push-to-registry:
     description: >
-      Whether to push the attestation to the image registry. Requires a single
-      fully-qualified OCI subject with a SHA-256 digest, supplied either
-      explicitly via "subject-name"/"subject-digest" or discovered from the
-      runner-provided artifacts list. Defaults to false.
+      Whether to push the attestation to the image registry. Requires that the
+      resolved subject is a single fully-qualified OCI image reference with a
+      SHA-256 digest, whether specified explicitly (via any subject input) or
+      discovered from the runner-provided artifacts list. Defaults to false.
     default: false
     required: false
   create-storage-record:

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -8,7 +8,7 @@ const SUPPORTED_VERSION = 1
 // Valid kinds and their allowed digest algorithms with expected hex lengths
 const DIGEST_RULES: Record<string, Record<string, number>> = {
   file: { sha256: 64 },
-  oci: { sha256: 64, sha384: 96, sha512: 128 }
+  oci: { sha256: 64 }
 }
 
 const HEX_RE = /^[0-9a-fA-F]+$/

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -1,0 +1,241 @@
+import fs from 'fs/promises'
+
+import type { Subject } from '@actions/attest'
+
+const ARTIFACTS_LIST_ENV = 'GITHUB_ARTIFACTS_LIST'
+const SUPPORTED_VERSION = 1
+
+// Valid kinds and their allowed digest algorithms with expected hex lengths
+const DIGEST_RULES: Record<string, Record<string, number>> = {
+  file: { sha256: 64 },
+  oci: { sha256: 64, sha384: 96, sha512: 128 }
+}
+
+const HEX_RE = /^[0-9a-fA-F]+$/
+
+export type ArtifactsListEntry = {
+  name: string
+  digest: string
+  kind: string
+}
+
+export type ArtifactsList = {
+  version: number
+  subjects: ArtifactsListEntry[]
+}
+
+export type ArtifactsListOptions = {
+  downcaseOCI?: boolean
+  requireSingleOCI?: boolean
+}
+
+/**
+ * Reads and parses the runner-generated artifacts list file identified by
+ * the $GITHUB_ARTIFACTS_LIST environment variable. Returns undefined when
+ * the env var is unset or blank (caller should treat this as "no discovered
+ * subjects").
+ *
+ * Throws on any structural, encoding, or validation error so the caller
+ * surfaces a clear failure rather than silently producing an empty list.
+ */
+export const readArtifactsList = async (
+  options?: ArtifactsListOptions
+): Promise<Subject[] | undefined> => {
+  const filePath = process.env[ARTIFACTS_LIST_ENV]
+  if (!filePath || filePath.trim() === '') {
+    return undefined
+  }
+
+  let raw: string
+  try {
+    raw = await fs.readFile(filePath, 'utf-8')
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new Error(`Failed to read artifacts list at "${filePath}": ${msg}`)
+  }
+
+  return parseArtifactsList(raw, options)
+}
+
+/**
+ * Parse and validate the JSON content of an artifacts list file.
+ */
+export const parseArtifactsList = (
+  content: string,
+  options?: ArtifactsListOptions
+): Subject[] => {
+  // Reject UTF-8 BOM (U+FEFF) — runner emits UTF-8 without BOM.
+  // Check before the whitespace test because String.prototype.trim()
+  // strips U+FEFF, so a BOM-only file would otherwise look empty.
+  if (content.charCodeAt(0) === 0xfeff) {
+    throw new Error(
+      'Artifacts list file contains a UTF-8 BOM; the file must be plain UTF-8'
+    )
+  }
+
+  // The runner intentionally leaves the file empty when the feature is off.
+  // Treat empty or whitespace-only content as "no discovered subjects".
+  if (content.trim() === '') {
+    return []
+  }
+
+  let data: unknown
+  try {
+    data = JSON.parse(content)
+  } catch {
+    throw new Error('Artifacts list file contains invalid JSON')
+  }
+
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+    throw new Error('Artifacts list must be a JSON object')
+  }
+
+  const obj = data as Record<string, unknown>
+
+  // Version check
+  if (obj.version !== SUPPORTED_VERSION) {
+    throw new Error(
+      `Unsupported artifacts list version: ${JSON.stringify(obj.version)} (expected ${SUPPORTED_VERSION})`
+    )
+  }
+
+  // Subjects array
+  if (!Array.isArray(obj.subjects)) {
+    throw new Error('Artifacts list is missing a "subjects" array')
+  }
+
+  const entries = obj.subjects as unknown[]
+  const subjects: Subject[] = []
+
+  // Track (normalizedName, kind, digest) for dedup and conflict detection
+  const seen = new Map<string, { kind: string; digest: string }>()
+
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i]
+    if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+      throw new Error(`Artifacts list entry ${i}: must be a JSON object`)
+    }
+
+    const e = entry as Record<string, unknown>
+    const { name: rawName, kind, digest } = validateEntry(e, i)
+
+    // Normalize OCI names to lowercase when requested (e.g. for registry push).
+    // This must happen before dedup so that case-only duplicates collapse and
+    // case-colliding names with different digests are detected as conflicts.
+    const name =
+      options?.downcaseOCI && kind === 'oci' ? rawName.toLowerCase() : rawName
+
+    // Check for conflicts or duplicates by normalized name
+    const prev = seen.get(name)
+    if (prev) {
+      if (prev.kind === kind && prev.digest === digest) {
+        // Exact duplicate — skip silently
+        continue
+      }
+      throw new Error(
+        `Artifacts list entry ${i}: duplicate name "${name}" with conflicting kind or digest`
+      )
+    }
+    seen.set(name, { kind, digest })
+
+    // Convert digest string "algorithm:hex" to Subject shape
+    const colonIdx = digest.indexOf(':')
+    const algorithm = digest.slice(0, colonIdx)
+    const hex = digest.slice(colonIdx + 1)
+
+    subjects.push({
+      name,
+      digest: { [algorithm]: hex }
+    })
+  }
+
+  // When requireSingleOCI is set (registry push flow), enforce that exactly
+  // one subject was discovered and that it is OCI-kind. This prevents file
+  // subjects from leaking into the registry push path.
+  if (options?.requireSingleOCI && subjects.length > 0) {
+    // Re-check kinds from the validated entries — we tracked them in `seen`
+    const kinds = [...seen.values()].map(v => v.kind)
+    const hasNonOCI = kinds.some(k => k !== 'oci')
+
+    if (hasNonOCI) {
+      throw new Error(
+        'push-to-registry requires an OCI subject but the discovered artifacts list contains file-kind subjects'
+      )
+    }
+    if (subjects.length > 1) {
+      throw new Error(
+        'push-to-registry requires exactly one subject but the discovered artifacts list contains multiple subjects'
+      )
+    }
+  }
+
+  return subjects
+}
+
+/**
+ * Validate a single entry from the artifacts list. Returns the validated
+ * name, kind, and digest string on success; throws with a contextual
+ * message on failure.
+ */
+const validateEntry = (
+  entry: Record<string, unknown>,
+  index: number
+): { name: string; kind: string; digest: string } => {
+  // name
+  if (typeof entry.name !== 'string' || entry.name === '') {
+    throw new Error(
+      `Artifacts list entry ${index}: "name" must be a non-empty string`
+    )
+  }
+  const name = entry.name
+
+  // kind
+  if (typeof entry.kind !== 'string') {
+    throw new Error(`Artifacts list entry ${index}: "kind" must be a string`)
+  }
+  const kind = entry.kind
+  const allowedAlgorithms = DIGEST_RULES[kind]
+  if (!allowedAlgorithms) {
+    throw new Error(
+      `Artifacts list entry ${index}: unsupported kind "${kind}" (expected "file" or "oci")`
+    )
+  }
+
+  // digest — must be "algorithm:hex"
+  if (typeof entry.digest !== 'string' || entry.digest === '') {
+    throw new Error(
+      `Artifacts list entry ${index}: "digest" must be a non-empty string`
+    )
+  }
+  const digest = entry.digest
+  const colonIdx = digest.indexOf(':')
+  if (colonIdx === -1) {
+    throw new Error(
+      `Artifacts list entry ${index}: digest must be in the format "algorithm:hex"`
+    )
+  }
+  const algorithm = digest.slice(0, colonIdx)
+  const hex = digest.slice(colonIdx + 1)
+
+  const expectedLen = allowedAlgorithms[algorithm]
+  if (expectedLen === undefined) {
+    const allowed = Object.keys(allowedAlgorithms).join(', ')
+    throw new Error(
+      `Artifacts list entry ${index}: algorithm "${algorithm}" is not allowed for kind "${kind}" (allowed: ${allowed})`
+    )
+  }
+
+  if (!HEX_RE.test(hex)) {
+    throw new Error(
+      `Artifacts list entry ${index}: digest contains invalid hex characters`
+    )
+  }
+
+  if (hex.length !== expectedLen) {
+    throw new Error(
+      `Artifacts list entry ${index}: digest has ${hex.length} hex characters but "${algorithm}" requires exactly ${expectedLen}`
+    )
+  }
+
+  return { name, kind, digest }
+}

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -30,6 +30,12 @@ export type ArtifactsListOptions = {
 }
 
 /**
+ * Extracts a displayable message from an unknown caught value.
+ */
+export const errorMessage = (err: unknown): string =>
+  err instanceof Error ? err.message : String(err)
+
+/**
  * Reads and parses the runner-generated artifacts list file identified by
  * the $GITHUB_ARTIFACTS_LIST environment variable. Returns undefined when
  * the env var is unset or blank (caller should treat this as "no discovered
@@ -50,7 +56,7 @@ export const readArtifactsList = async (
   try {
     raw = await fs.readFile(filePath, 'utf-8')
   } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err)
+    const msg = errorMessage(err)
     throw new Error(`Failed to read artifacts list at "${filePath}": ${msg}`)
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,6 +88,11 @@ export async function run(inputs: RunInputs): Promise<void> {
       downcaseName: inputs.pushToRegistry
     })
 
+    // Validate subjects are compatible with registry push requirements
+    if (inputs.pushToRegistry) {
+      validateRegistrySubjects(subjects)
+    }
+
     // Generate predicate based on attestation type
     const predicate = await getPredicateForType(attestationType, inputs)
 
@@ -264,5 +269,25 @@ const getPredicateForType = async (
     }
     case 'custom':
       return predicateFromInputs(inputs)
+  }
+}
+
+// Validate that resolved subjects meet registry push requirements:
+// exactly one subject with a SHA-256 digest.
+export const validateRegistrySubjects = (subjects: Subject[]): void => {
+  if (subjects.length !== 1) {
+    throw new Error(
+      `push-to-registry requires exactly one subject but ${subjects.length} subjects were resolved`
+    )
+  }
+
+  const subject = subjects[0]
+  const algorithms = Object.keys(subject.digest)
+  const hasNonSHA256 = algorithms.some(alg => alg !== 'sha256')
+
+  if (hasNonSHA256 || !algorithms.includes('sha256')) {
+    throw new Error(
+      `push-to-registry requires a subject with a SHA-256 digest but the subject has: ${algorithms.join(', ')}`
+    )
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,6 +88,18 @@ export async function run(inputs: RunInputs): Promise<void> {
       downcaseName: inputs.pushToRegistry
     })
 
+    // When pushing to an OCI registry, every subject must use sha256 digests
+    if (inputs.pushToRegistry) {
+      for (const subject of subjects) {
+        const algorithms = Object.keys(subject.digest)
+        if (algorithms.length !== 1 || algorithms[0] !== 'sha256') {
+          throw new Error(
+            'push-to-registry requires all subjects to have sha256 digests'
+          )
+        }
+      }
+    }
+
     // Generate predicate based on attestation type
     const predicate = await getPredicateForType(attestationType, inputs)
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,18 +88,6 @@ export async function run(inputs: RunInputs): Promise<void> {
       downcaseName: inputs.pushToRegistry
     })
 
-    // When pushing to an OCI registry, every subject must use sha256 digests
-    if (inputs.pushToRegistry) {
-      for (const subject of subjects) {
-        const algorithms = Object.keys(subject.digest)
-        if (algorithms.length !== 1 || algorithms[0] !== 'sha256') {
-          throw new Error(
-            'push-to-registry requires all subjects to have sha256 digests'
-          )
-        }
-      }
-    }
-
     // Generate predicate based on attestation type
     const predicate = await getPredicateForType(attestationType, inputs)
 

--- a/src/subject.ts
+++ b/src/subject.ts
@@ -47,6 +47,11 @@ export const subjectFromInputs = async (
       requireSingleOCI: downcaseName
     })
     if (discovered && discovered.length > 0) {
+      if (discovered.length > MAX_SUBJECT_COUNT) {
+        throw new Error(
+          `Too many subjects specified (>${MAX_SUBJECT_COUNT}). The maximum number of subjects is ${MAX_SUBJECT_COUNT}.`
+        )
+      }
       return discovered
     }
 

--- a/src/subject.ts
+++ b/src/subject.ts
@@ -145,7 +145,7 @@ const getSubjectFromDigest = (
   subjectDigest: string,
   subjectName: string
 ): Subject => {
-  if (!subjectDigest.match(/^sha256:[A-Za-z0-9]{64}$/)) {
+  if (!subjectDigest.match(/^sha256:[0-9a-fA-F]{64}$/)) {
     throw new Error(
       'subject-digest must be in the format "sha256:<hex-digest>"'
     )

--- a/src/subject.ts
+++ b/src/subject.ts
@@ -6,6 +6,8 @@ import { createReadStream } from 'fs'
 import fs from 'fs/promises'
 import path from 'path'
 
+import { readArtifactsList } from './artifacts'
+
 import type { Subject } from '@actions/attest'
 
 const MAX_SUBJECT_COUNT = 1024
@@ -39,6 +41,15 @@ export const subjectFromInputs = async (
     Boolean
   )
   if (enabledInputs.length === 0) {
+    // No explicit subject input — try the runner-generated artifacts list
+    const discovered = await readArtifactsList({
+      downcaseOCI: downcaseName,
+      requireSingleOCI: downcaseName
+    })
+    if (discovered && discovered.length > 0) {
+      return discovered
+    }
+
     throw new Error(
       'One of subject-path, subject-digest, or subject-checksums must be provided'
     )


### PR DESCRIPTION
When none of the explicit subject inputs (`subject-path`, `subject-digest`,
`subject-checksums`) are provided, the action now falls back to subjects
discovered from the runner-provided `$GITHUB_ARTIFACTS_LIST` environment
variable. This variable, introduced in [actions/runner#4527](https://github.com/actions/runner/pull/4527),
points to a JSON file describing artifacts produced during the workflow.

**Key behaviors:**

- **Explicit-input precedence**: when any explicit subject input is provided,
  `$GITHUB_ARTIFACTS_LIST` is never consulted.
- **SHA-256 only**: all discovered subjects (both `file` and `oci` kinds)
  must use `sha256` digests. Other algorithms are rejected at parse time.
- **Strict validation**: the artifacts list JSON is validated against a strict
  schema — version, entry structure, kind-specific digest algorithm rules,
  and hex format/length.
- **Registry constraints**: when `push-to-registry` is enabled, discovered
  subjects must contain exactly one OCI-kind entry. File-kind subjects and
  multi-subject lists are rejected early with clear error messages.
- **OCI name normalization**: OCI subject names are lowercased before
  duplicate detection when the registry push flow is active, ensuring
  case-only duplicates are collapsed and case-colliding names with
  conflicting digests are caught.
- **Deterministic dedup/conflict**: exact (name, kind, digest) duplicates
  are silently deduplicated; same-name entries with differing kind or
  digest are rejected.

**Tests**: comprehensive unit tests for the new `parseArtifactsList` parser
(structural validation, version checks, entry validation, kind-specific
algorithm rules, dedup/conflicts, OCI normalization, registry constraints)
plus integration tests covering the full `run()` flow with discovered
subjects, registry rejection, and explicit-input precedence.