### PR TITLE
Add release-cutter canvas extension

### DIFF
--- a/.github/extensions/release-cutter/backend.mjs
+++ b/.github/extensions/release-cutter/backend.mjs
@@ -161,6 +161,9 @@ export function parseNotesBody(body) {
 
 /** Ask GitHub to generate release notes for a tag range and parse them. */
 export async function generateNotes(cwd, { tag, previousTag, targetCommitish }) {
+    if (!parseVersion(tag)) {
+        throw new Error(`Tag must be a v-prefixed semver like v4.2.1 (got: ${tag ?? "<missing>"})`);
+    }
     const repo = await resolveRepo(cwd);
     const args = ["api", `repos/${repo}/releases/generate-notes`, "-f", `tag_name=${tag}`];
     if (previousTag) args.push("-f", `previous_tag_name=${previousTag}`);
@@ -168,11 +171,14 @@ export async function generateNotes(cwd, { tag, previousTag, targetCommitish }) 
     const out = await gh(args);
     const parsed = JSON.parse(out);
     const { items, footer } = parseNotesBody(parsed.body);
+    const fallbackFooter = previousTag
+        ? `**Full Changelog**: https://github.com/${repo}/compare/${previousTag}...${tag}`
+        : `**Full Changelog**: https://github.com/${repo}/commits/${tag}`;
     return {
         repo,
         name: parsed.name || tag,
         items,
-        footer: footer || `**Full Changelog**: https://github.com/${repo}/compare/${previousTag || ""}...${tag}`,
+        footer: footer || fallbackFooter,
     };
 }
 

--- a/.github/extensions/release-cutter/backend.mjs
+++ b/.github/extensions/release-cutter/backend.mjs
@@ -1,0 +1,249 @@
+// Backend helpers for the release-cutter canvas.
+//
+// All GitHub interaction goes through the `gh` CLI (already authenticated in
+// the user's environment) and `git`. Nothing here writes to disk except a
+// short-lived temp file for the release notes body.
+
+import { execFile } from "node:child_process";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/** Run a command, resolving with stdout. Rejects with stderr on non-zero exit. */
+function run(cmd, args, opts = {}) {
+    return new Promise((resolve, reject) => {
+        execFile(cmd, args, { maxBuffer: 16 * 1024 * 1024, ...opts }, (err, stdout, stderr) => {
+            if (err) {
+                const message = (stderr || err.message || "").toString().trim();
+                reject(new Error(message || `${cmd} exited with an error`));
+                return;
+            }
+            resolve(stdout.toString());
+        });
+    });
+}
+
+const gh = (args, opts) => run("gh", args, opts);
+
+/** Resolve owner/repo for the workspace. Falls back to the git remote. */
+export async function resolveRepo(cwd) {
+    try {
+        const out = await gh(["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"], { cwd });
+        const repo = out.trim();
+        if (repo) return repo;
+    } catch {
+        // fall through to git remote parsing
+    }
+    const remote = (await run("git", ["remote", "get-url", "origin"], { cwd })).trim();
+    const match = remote.match(/[:/]([^/]+\/[^/]+?)(?:\.git)?$/);
+    if (!match) throw new Error(`Could not determine repository from remote: ${remote}`);
+    return match[1];
+}
+
+const SEMVER = /^v(\d+)\.(\d+)\.(\d+)$/;
+
+/** Parse a `vMAJOR.MINOR.PATCH` tag into numbers, or null. */
+export function parseVersion(tag) {
+    const m = typeof tag === "string" ? tag.match(SEMVER) : null;
+    if (!m) return null;
+    return { major: Number(m[1]), minor: Number(m[2]), patch: Number(m[3]) };
+}
+
+/** Compute suggested next tags from a base version. */
+export function suggestVersions(baseTag) {
+    const v = parseVersion(baseTag) || { major: 0, minor: 0, patch: 0 };
+    return {
+        patch: `v${v.major}.${v.minor}.${v.patch + 1}`,
+        minor: `v${v.major}.${v.minor + 1}.0`,
+        major: `v${v.major + 1}.0.0`,
+    };
+}
+
+/** The floating major tag for a version tag, e.g. v4.2.1 -> v4. */
+export function majorTagFor(tag) {
+    const v = parseVersion(tag);
+    return v ? `v${v.major}` : null;
+}
+
+/** Gather everything the canvas needs to render its initial state. */
+export async function getStatus(cwd) {
+    const repo = await resolveRepo(cwd);
+
+    let latestRelease = null;
+    try {
+        const out = await gh([
+            "release",
+            "view",
+            "--repo",
+            repo,
+            "--json",
+            "tagName,name,url,createdAt,isDraft,isPrerelease",
+        ]);
+        latestRelease = JSON.parse(out);
+    } catch {
+        latestRelease = null; // repo may have no releases yet
+    }
+
+    const defaultBranch = (
+        await gh(["repo", "view", repo, "--json", "defaultBranchRef", "--jq", ".defaultBranchRef.name"])
+    ).trim();
+
+    const baseTag = latestRelease?.tagName || "v0.0.0";
+    const suggested = suggestVersions(baseTag);
+
+    // Current target of the floating major tag (informational only).
+    let majorTag = majorTagFor(suggested.patch);
+    let majorTagSha = null;
+    if (majorTag) {
+        try {
+            majorTagSha = (await gh(["api", `repos/${repo}/git/ref/tags/${majorTag}`, "--jq", ".object.sha"])).trim();
+        } catch {
+            majorTagSha = null;
+        }
+    }
+
+    return {
+        repo,
+        defaultBranch,
+        latestRelease,
+        suggested,
+        defaultTag: suggested.patch,
+        majorTag,
+        majorTagSha,
+    };
+}
+
+/**
+ * Classify a changelog line so we can pre-select which commits are relevant to
+ * action consumers. Dependabot bumps to dev dependencies and to GitHub Actions
+ * are excluded by default; everything else is included.
+ */
+export function classifyLine(text) {
+    const isDependabot = /@dependabot(\[bot\])?/i.test(text);
+    if (!isDependabot) {
+        return { category: "change", include: true };
+    }
+    const lower = text.toLowerCase();
+    // npm scoped packages (@scope/name) are dev/prod deps, not GitHub Actions,
+    // so classify those before falling through to the actions heuristics.
+    const isDev =
+        /\bnpm-development\b/.test(lower) ||
+        /development group/.test(lower) ||
+        /@types\//.test(text);
+    const isActions =
+        /actions-(minor|major|patch)\b/.test(lower) ||
+        /\bthe actions[- ]/.test(lower) ||
+        /\bgithub-actions\b/.test(lower) ||
+        // Bump owner/name (no leading @) is an action repo, e.g. actions/checkout.
+        /\bbump\s+(?!@)[\w.-]+\/[\w.-]+\s+from\b/.test(lower);
+    if (isDev) return { category: "dependabot-dev", include: false };
+    if (isActions) return { category: "dependabot-actions", include: false };
+    return { category: "dependabot-prod", include: true };
+}
+
+/** Split a generated-notes body into a header, item lines, and footer. */
+export function parseNotesBody(body) {
+    const lines = (body || "").split("\n");
+    const items = [];
+    let footer = "";
+    for (const line of lines) {
+        const trimmed = line.trimEnd();
+        if (/^\*\s+/.test(trimmed)) {
+            const text = trimmed.replace(/^\*\s+/, "");
+            const { category, include } = classifyLine(text);
+            items.push({ id: items.length, text, category, include });
+        } else if (/^\*\*Full Changelog\*\*:/.test(trimmed)) {
+            footer = trimmed;
+        }
+    }
+    return { items, footer };
+}
+
+/** Ask GitHub to generate release notes for a tag range and parse them. */
+export async function generateNotes(cwd, { tag, previousTag, targetCommitish }) {
+    const repo = await resolveRepo(cwd);
+    const args = ["api", `repos/${repo}/releases/generate-notes`, "-f", `tag_name=${tag}`];
+    if (previousTag) args.push("-f", `previous_tag_name=${previousTag}`);
+    if (targetCommitish) args.push("-f", `target_commitish=${targetCommitish}`);
+    const out = await gh(args);
+    const parsed = JSON.parse(out);
+    const { items, footer } = parseNotesBody(parsed.body);
+    return {
+        repo,
+        name: parsed.name || tag,
+        items,
+        footer: footer || `**Full Changelog**: https://github.com/${repo}/compare/${previousTag || ""}...${tag}`,
+    };
+}
+
+/** Rebuild a release body from the selected item lines plus the footer. */
+export function composeBody(includedTexts, footer) {
+    const parts = [];
+    if (includedTexts.length > 0) {
+        parts.push("## What's Changed");
+        for (const text of includedTexts) parts.push(`* ${text}`);
+    }
+    if (footer) {
+        if (parts.length > 0) parts.push("");
+        parts.push(footer);
+    }
+    return parts.join("\n");
+}
+
+/**
+ * Publish the release (never draft, never with assets) then force-move the
+ * floating major tag to the newly released commit.
+ */
+export async function publishRelease(cwd, { tag, name, body, targetCommitish }) {
+    const repo = await resolveRepo(cwd);
+    const version = parseVersion(tag);
+    if (!version) throw new Error(`Tag must be a v-prefixed semver like v4.2.1 (got: ${tag})`);
+
+    const dir = await mkdtemp(join(tmpdir(), "release-cutter-"));
+    const notesFile = join(dir, "notes.md");
+    await writeFile(notesFile, body ?? "", "utf8");
+
+    try {
+        const createArgs = [
+            "release",
+            "create",
+            tag,
+            "--repo",
+            repo,
+            "--title",
+            name || tag,
+            "--notes-file",
+            notesFile,
+        ];
+        if (targetCommitish) createArgs.push("--target", targetCommitish);
+        const createOut = await gh(createArgs);
+        const releaseUrl = createOut.trim().split("\n").pop().trim();
+
+        // Resolve the commit the new tag points at, then move the major tag.
+        const sha = (await gh(["api", `repos/${repo}/git/ref/tags/${tag}`, "--jq", ".object.sha"])).trim();
+        const majorTag = majorTagFor(tag);
+        let movedMajor = null;
+        if (majorTag) {
+            try {
+                await gh([
+                    "api",
+                    "-X",
+                    "PATCH",
+                    `repos/${repo}/git/refs/tags/${majorTag}`,
+                    "-f",
+                    `sha=${sha}`,
+                    "-F",
+                    "force=true",
+                ]);
+            } catch {
+                // Ref may not exist yet (first release of a major) -> create it.
+                await gh(["api", "-X", "POST", `repos/${repo}/git/refs`, "-f", `ref=refs/tags/${majorTag}`, "-f", `sha=${sha}`]);
+            }
+            movedMajor = { tag: majorTag, sha };
+        }
+
+        return { repo, tag, releaseUrl, sha, movedMajor };
+    } finally {
+        await rm(dir, { recursive: true, force: true });
+    }
+}

--- a/.github/extensions/release-cutter/extension.mjs
+++ b/.github/extensions/release-cutter/extension.mjs
@@ -12,11 +12,13 @@
 // UI is in renderer.mjs.
 
 import { createServer } from "node:http";
+import { randomUUID } from "node:crypto";
 import { joinSession, createCanvas, CanvasError } from "@github/copilot-sdk/extension";
 import { renderHtml } from "./renderer.mjs";
 import { getStatus, generateNotes, publishRelease } from "./backend.mjs";
 
-// One loopback server per open canvas instance.
+// One loopback server per open canvas instance. Each carries a random token so
+// only the iframe we handed the URL to can reach the (publish-capable) API.
 const servers = new Map();
 
 let workspacePath = process.cwd();
@@ -24,18 +26,28 @@ let workspacePath = process.cwd();
 function readJsonBody(req) {
     return new Promise((resolve, reject) => {
         let data = "";
+        let settled = false;
+        const finish = (fn, value) => {
+            if (settled) return;
+            settled = true;
+            fn(value);
+        };
         req.on("data", (chunk) => {
+            if (settled) return;
             data += chunk;
-            if (data.length > 4 * 1024 * 1024) reject(new Error("Request body too large"));
+            if (data.length > 4 * 1024 * 1024) {
+                req.destroy();
+                finish(reject, new Error("Request body too large"));
+            }
         });
         req.on("end", () => {
             try {
-                resolve(data ? JSON.parse(data) : {});
+                finish(resolve, data ? JSON.parse(data) : {});
             } catch (e) {
-                reject(e);
+                finish(reject, e);
             }
         });
-        req.on("error", reject);
+        req.on("error", (e) => finish(reject, e));
     });
 }
 
@@ -45,13 +57,21 @@ function sendJson(res, status, payload) {
     res.end(body);
 }
 
-async function handleRequest(req, res) {
+async function handleRequest(req, res, token) {
     try {
         const url = new URL(req.url, "http://127.0.0.1");
         if (req.method === "GET" && url.pathname === "/") {
             res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
             res.end(renderHtml());
             return;
+        }
+        // Everything below is a state-changing / data API: require the token.
+        if (url.pathname.startsWith("/api/")) {
+            const provided = url.searchParams.get("t") || req.headers["x-canvas-token"];
+            if (provided !== token) {
+                sendJson(res, 403, { error: "Forbidden" });
+                return;
+            }
         }
         if (req.method === "GET" && url.pathname === "/api/status") {
             const status = await getStatus(workspacePath);
@@ -73,16 +93,17 @@ async function handleRequest(req, res) {
         res.writeHead(404, { "Content-Type": "text/plain" });
         res.end("Not found");
     } catch (err) {
-        sendJson(res, 200, { error: err?.message || String(err) });
+        sendJson(res, 500, { error: err?.message || String(err) });
     }
 }
 
 async function startServer() {
-    const server = createServer(handleRequest);
+    const token = randomUUID();
+    const server = createServer((req, res) => handleRequest(req, res, token));
     await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
     const address = server.address();
     const port = typeof address === "object" && address ? address.port : 0;
-    return { server, url: `http://127.0.0.1:${port}/` };
+    return { server, url: `http://127.0.0.1:${port}/?t=${token}` };
 }
 
 const session = await joinSession({

--- a/.github/extensions/release-cutter/extension.mjs
+++ b/.github/extensions/release-cutter/extension.mjs
@@ -1,0 +1,172 @@
+// Extension: release-cutter
+//
+// A canvas that walks you through cutting a new release of the action:
+//   1. Pick the next v-prefixed semver tag (patch / minor / major bump).
+//   2. Generate release notes from the commits since the last release, with
+//      dependabot dev-dependency and GitHub Actions bumps pre-excluded.
+//   3. Curate the notes (toggle lines or edit raw markdown).
+//   4. Publish the GitHub Release (never a draft, never with assets), then
+//      force-move the floating major tag (e.g. v4) to the new release.
+//
+// Wiring lives here; the changelog/gh logic is in backend.mjs and the iframe
+// UI is in renderer.mjs.
+
+import { createServer } from "node:http";
+import { joinSession, createCanvas, CanvasError } from "@github/copilot-sdk/extension";
+import { renderHtml } from "./renderer.mjs";
+import { getStatus, generateNotes, publishRelease } from "./backend.mjs";
+
+// One loopback server per open canvas instance.
+const servers = new Map();
+
+let workspacePath = process.cwd();
+
+function readJsonBody(req) {
+    return new Promise((resolve, reject) => {
+        let data = "";
+        req.on("data", (chunk) => {
+            data += chunk;
+            if (data.length > 4 * 1024 * 1024) reject(new Error("Request body too large"));
+        });
+        req.on("end", () => {
+            try {
+                resolve(data ? JSON.parse(data) : {});
+            } catch (e) {
+                reject(e);
+            }
+        });
+        req.on("error", reject);
+    });
+}
+
+function sendJson(res, status, payload) {
+    const body = JSON.stringify(payload);
+    res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
+    res.end(body);
+}
+
+async function handleRequest(req, res) {
+    try {
+        const url = new URL(req.url, "http://127.0.0.1");
+        if (req.method === "GET" && url.pathname === "/") {
+            res.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+            res.end(renderHtml());
+            return;
+        }
+        if (req.method === "GET" && url.pathname === "/api/status") {
+            const status = await getStatus(workspacePath);
+            sendJson(res, 200, status);
+            return;
+        }
+        if (req.method === "POST" && url.pathname === "/api/notes") {
+            const body = await readJsonBody(req);
+            const notes = await generateNotes(workspacePath, body);
+            sendJson(res, 200, notes);
+            return;
+        }
+        if (req.method === "POST" && url.pathname === "/api/publish") {
+            const body = await readJsonBody(req);
+            const result = await publishRelease(workspacePath, body);
+            sendJson(res, 200, result);
+            return;
+        }
+        res.writeHead(404, { "Content-Type": "text/plain" });
+        res.end("Not found");
+    } catch (err) {
+        sendJson(res, 200, { error: err?.message || String(err) });
+    }
+}
+
+async function startServer() {
+    const server = createServer(handleRequest);
+    await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    return { server, url: `http://127.0.0.1:${port}/` };
+}
+
+const session = await joinSession({
+    canvases: [
+        createCanvas({
+            id: "release-cutter",
+            displayName: "Cut a release",
+            description:
+                "Guides publishing a new GitHub Release for the action: pick the next v-semver tag, curate auto-generated notes, publish, and force-move the major tag.",
+            actions: [
+                {
+                    name: "get_status",
+                    description:
+                        "Return the latest release, suggested next tags (patch/minor/major), and the floating major tag for this repo.",
+                    handler: async () => {
+                        try {
+                            return await getStatus(workspacePath);
+                        } catch (err) {
+                            throw new CanvasError("status_failed", err?.message || String(err));
+                        }
+                    },
+                },
+                {
+                    name: "generate_notes",
+                    description:
+                        "Generate and classify release notes for a tag range. Input: { tag, previousTag?, targetCommitish? }.",
+                    inputSchema: {
+                        type: "object",
+                        properties: {
+                            tag: { type: "string", description: "The new v-prefixed semver tag, e.g. v4.2.1" },
+                            previousTag: { type: "string", description: "Previous release tag to diff from" },
+                            targetCommitish: { type: "string", description: "Branch or SHA the release targets" },
+                        },
+                        required: ["tag"],
+                    },
+                    handler: async (ctx) => {
+                        try {
+                            return await generateNotes(workspacePath, ctx.input || {});
+                        } catch (err) {
+                            throw new CanvasError("notes_failed", err?.message || String(err));
+                        }
+                    },
+                },
+                {
+                    name: "publish_release",
+                    description:
+                        "Publish a GitHub Release (no assets, not a draft) and force-move the major tag. Input: { tag, name?, body?, targetCommitish? }.",
+                    inputSchema: {
+                        type: "object",
+                        properties: {
+                            tag: { type: "string", description: "The new v-prefixed semver tag, e.g. v4.2.1" },
+                            name: { type: "string", description: "Release title (defaults to the tag)" },
+                            body: { type: "string", description: "Release body markdown" },
+                            targetCommitish: { type: "string", description: "Branch or SHA the release targets" },
+                        },
+                        required: ["tag"],
+                    },
+                    handler: async (ctx) => {
+                        try {
+                            return await publishRelease(workspacePath, ctx.input || {});
+                        } catch (err) {
+                            throw new CanvasError("publish_failed", err?.message || String(err));
+                        }
+                    },
+                },
+            ],
+            open: async (ctx) => {
+                if (ctx.session?.workingDirectory) workspacePath = ctx.session.workingDirectory;
+                let entry = servers.get(ctx.instanceId);
+                if (!entry) {
+                    entry = await startServer();
+                    servers.set(ctx.instanceId, entry);
+                }
+                return { title: "Cut a release", url: entry.url };
+            },
+            onClose: async (ctx) => {
+                const entry = servers.get(ctx.instanceId);
+                if (entry) {
+                    servers.delete(ctx.instanceId);
+                    await new Promise((resolve) => entry.server.close(() => resolve()));
+                }
+            },
+        }),
+    ],
+});
+
+if (session.workspacePath) workspacePath = session.workspacePath;

--- a/.github/extensions/release-cutter/renderer.mjs
+++ b/.github/extensions/release-cutter/renderer.mjs
@@ -166,7 +166,6 @@ export function renderHtml() {
       </div>
       <ul id="items" class="items"></ul>
       <textarea id="raw" class="hidden"></textarea>
-      <div class="hint" id="raw-hint hidden"></div>
     </div>
   </div>
 
@@ -181,10 +180,32 @@ export function renderHtml() {
 const $ = (id) => document.getElementById(id);
 let state = { repo: "", suggested: {}, latestTag: "", footer: "", items: [], rawMode: false, rawText: "" };
 
-function showBanner(kind, html) {
+// Per-instance token handed to us in the iframe URL; required on every API call.
+const TOKEN = new URLSearchParams(location.search).get("t") || "";
+function api(path) {
+  return path + (path.includes("?") ? "&" : "?") + "t=" + encodeURIComponent(TOKEN);
+}
+
+// Banner content is built from DOM nodes (strings become text nodes) so that
+// CLI/gh output interpolated into messages can never inject HTML.
+function showBanner(kind, ...parts) {
   const b = $("banner");
-  if (!kind) { b.innerHTML = ""; return; }
-  b.innerHTML = '<div class="banner ' + kind + '">' + html + '</div>';
+  b.textContent = "";
+  if (!kind) return;
+  const div = document.createElement("div");
+  div.className = "banner " + kind;
+  for (const p of parts) {
+    if (p == null) continue;
+    div.appendChild(typeof p === "string" ? document.createTextNode(p) : p);
+  }
+  b.appendChild(div);
+}
+
+function mono(text) {
+  const s = document.createElement("span");
+  s.className = "mono";
+  s.textContent = text;
+  return s;
 }
 
 function isValidTag(t) { return /^v\\d+\\.\\d+\\.\\d+$/.test(t); }
@@ -257,13 +278,15 @@ function renderItems() {
 
 async function loadStatus() {
   try {
-    const r = await fetch("/api/status");
+    const r = await fetch(api("/api/status"));
     const s = await r.json();
     if (s.error) throw new Error(s.error);
     state.repo = s.repo;
     state.suggested = s.suggested;
     state.latestTag = s.latestRelease ? s.latestRelease.tagName : "";
-    $("subtitle").innerHTML = "Repository <span class='mono'>" + s.repo + "</span> · default branch <span class='mono'>" + s.defaultBranch + "</span>";
+    const sub = $("subtitle");
+    sub.textContent = "";
+    sub.append("Repository ", mono(s.repo), " · default branch ", mono(s.defaultBranch));
     $("latest").textContent = s.latestRelease ? s.latestRelease.tagName : "(none)";
     $("major").textContent = s.majorTag || "—";
     $("tag").value = s.defaultTag || "";
@@ -280,7 +303,7 @@ async function generate() {
   showBanner(null);
   $("regen").disabled = true; $("regen").textContent = "Generating…";
   try {
-    const r = await fetch("/api/notes", {
+    const r = await fetch(api("/api/notes"), {
       method: "POST", headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ tag, previousTag: state.latestTag }),
     });
@@ -313,15 +336,21 @@ async function publish() {
   showBanner(null);
   $("publish").disabled = true; $("publish").textContent = "Publishing…";
   try {
-    const r = await fetch("/api/publish", {
+    const r = await fetch(api("/api/publish"), {
       method: "POST", headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ tag, name: title, body }),
     });
     const data = await r.json();
     if (data.error) throw new Error(data.error);
-    let msg = "Published <a href='" + data.releaseUrl + "' target='_blank'>" + data.tag + "</a>.";
-    if (data.movedMajor) msg += " Moved <span class='mono'>" + data.movedMajor.tag + "</span> → <span class='mono'>" + data.movedMajor.sha.slice(0,7) + "</span>.";
-    showBanner("ok", msg);
+    const parts = ["Published "];
+    const link = document.createElement("a");
+    link.href = data.releaseUrl; link.target = "_blank"; link.rel = "noopener noreferrer";
+    link.textContent = data.tag;
+    parts.push(link, ".");
+    if (data.movedMajor) {
+      parts.push(" Moved ", mono(data.movedMajor.tag), " → ", mono(data.movedMajor.sha.slice(0, 7)), ".");
+    }
+    showBanner("ok", ...parts);
     $("publish").textContent = "Published";
   } catch (e) {
     showBanner("err", "Publish failed: " + e.message);

--- a/.github/extensions/release-cutter/renderer.mjs
+++ b/.github/extensions/release-cutter/renderer.mjs
@@ -1,0 +1,362 @@
+// Iframe renderer for the release-cutter canvas. Exported as a single HTML
+// string. The page talks to the extension's loopback server over fetch:
+//   GET  /api/status          -> initial repo/release/version data
+//   POST /api/notes           -> generated + classified changelog lines
+//   POST /api/publish         -> create release + move major tag
+//
+// The host mirrors app theme tokens onto this document, so we lean on the
+// documented semantic CSS variables rather than hardcoded colors.
+
+export function renderHtml() {
+    return `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Cut a release</title>
+<style>
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    padding: 20px;
+    background: var(--background-color-default, #ffffff);
+    color: var(--text-color-default, #1f2328);
+    font-family: var(--font-sans, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+    font-size: var(--text-body-medium, 14px);
+    line-height: var(--leading-body-medium, 20px);
+  }
+  h1 {
+    font-size: var(--text-title-large, 22px);
+    font-weight: var(--font-weight-semibold, 600);
+    margin: 0 0 4px;
+  }
+  h2 {
+    font-size: var(--text-title-small, 15px);
+    font-weight: var(--font-weight-semibold, 600);
+    margin: 0 0 8px;
+  }
+  .muted { color: var(--text-color-muted, #656d76); }
+  code, .mono { font-family: var(--font-mono, ui-monospace, SFMono-Regular, Consolas, monospace); }
+  a { color: var(--true-color-blue, #0969da); }
+  .card {
+    border: 1px solid var(--border-color-default, #d0d7de);
+    border-radius: 8px;
+    padding: 16px;
+    margin-bottom: 16px;
+    background: var(--background-color-default, #fff);
+  }
+  .row { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+  .grow { flex: 1 1 auto; }
+  label.field { display: block; margin-bottom: 4px; font-weight: var(--font-weight-semibold, 600); }
+  input[type=text] {
+    width: 100%;
+    padding: 6px 10px;
+    border: 1px solid var(--border-color-default, #d0d7de);
+    border-radius: 6px;
+    background: var(--background-color-inset, transparent);
+    color: inherit;
+    font: inherit;
+  }
+  input.mono { font-family: var(--font-mono, ui-monospace, monospace); }
+  button {
+    font: inherit;
+    padding: 6px 12px;
+    border-radius: 6px;
+    border: 1px solid var(--border-color-default, #d0d7de);
+    background: var(--background-color-default, #f6f8fa);
+    color: inherit;
+    cursor: pointer;
+  }
+  button:hover:not(:disabled) { border-color: var(--text-color-muted, #656d76); }
+  button:disabled { opacity: 0.5; cursor: not-allowed; }
+  button.primary {
+    background: var(--true-color-green, #1f883d);
+    border-color: var(--true-color-green, #1f883d);
+    color: var(--color-white, #fff);
+    font-weight: var(--font-weight-semibold, 600);
+  }
+  button.seg { padding: 5px 10px; }
+  button.seg.active {
+    background: var(--true-color-blue, #0969da);
+    border-color: var(--true-color-blue, #0969da);
+    color: var(--color-white, #fff);
+  }
+  .items { list-style: none; margin: 0; padding: 0; }
+  .item {
+    display: flex; gap: 10px; align-items: flex-start;
+    padding: 8px; border-radius: 6px;
+  }
+  .item:hover { background: var(--background-color-inset, rgba(127,127,127,0.06)); }
+  .item.excluded .item-text { text-decoration: line-through; color: var(--text-color-muted, #656d76); }
+  .item input[type=checkbox] { margin-top: 3px; }
+  .item-text { flex: 1 1 auto; word-break: break-word; }
+  .badge {
+    font-size: 11px; padding: 1px 7px; border-radius: 999px; white-space: nowrap;
+    border: 1px solid var(--border-color-default, #d0d7de);
+    color: var(--text-color-muted, #656d76);
+  }
+  .badge.dep { border-color: var(--true-color-yellow-muted, #d4a72c); }
+  textarea {
+    width: 100%; min-height: 240px; padding: 10px;
+    border: 1px solid var(--border-color-default, #d0d7de);
+    border-radius: 6px; background: var(--background-color-inset, transparent);
+    color: inherit; font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 12px; line-height: 1.5;
+  }
+  .hint { font-size: 12px; color: var(--text-color-muted, #656d76); margin-top: 4px; }
+  .banner { padding: 10px 14px; border-radius: 6px; margin-bottom: 16px; }
+  .banner.err { background: var(--true-color-red-muted, rgba(207,34,46,0.12)); border: 1px solid var(--true-color-red, #cf222e); }
+  .banner.ok { background: var(--true-color-green-muted, rgba(31,136,61,0.12)); border: 1px solid var(--true-color-green, #1f883d); }
+  .toolbar { display: flex; gap: 8px; margin-bottom: 10px; flex-wrap: wrap; }
+  .spacer { flex: 1 1 auto; }
+  .hidden { display: none; }
+</style>
+</head>
+<body>
+  <h1>Cut a release</h1>
+  <div id="subtitle" class="muted">Loading…</div>
+
+  <div id="banner"></div>
+
+  <div class="card" id="version-card">
+    <h2>Version</h2>
+    <div class="row" style="margin-bottom: 12px;">
+      <div>
+        <div class="muted" style="font-size:12px;">Latest release</div>
+        <div id="latest" class="mono">—</div>
+      </div>
+      <div style="margin-left:24px;">
+        <div class="muted" style="font-size:12px;">Major tag to move</div>
+        <div id="major" class="mono">—</div>
+      </div>
+    </div>
+    <div class="row" style="margin-bottom:12px;">
+      <span class="muted">Bump:</span>
+      <button class="seg" data-bump="patch">patch</button>
+      <button class="seg" data-bump="minor">minor</button>
+      <button class="seg" data-bump="major">major</button>
+    </div>
+    <div class="row">
+      <div class="grow">
+        <label class="field" for="tag">New tag</label>
+        <input id="tag" type="text" class="mono" placeholder="v4.2.1" />
+        <div id="tag-hint" class="hint"></div>
+      </div>
+      <div class="grow">
+        <label class="field" for="title">Release title</label>
+        <input id="title" type="text" placeholder="v4.2.1" />
+      </div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="row" style="margin-bottom:12px;">
+      <h2 style="margin:0;">Release notes</h2>
+      <div class="spacer"></div>
+      <button id="regen">Generate from commits</button>
+    </div>
+    <div id="notes-empty" class="muted">Click “Generate from commits” to load the changes since the last release. Dependabot dev-dependency and GitHub Actions bumps are pre-unchecked.</div>
+    <div id="notes-body" class="hidden">
+      <div class="toolbar">
+        <button id="check-all">Select all</button>
+        <button id="check-none">Clear all</button>
+        <div class="spacer"></div>
+        <button id="toggle-edit">Edit raw markdown</button>
+      </div>
+      <ul id="items" class="items"></ul>
+      <textarea id="raw" class="hidden"></textarea>
+      <div class="hint" id="raw-hint hidden"></div>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="row">
+      <div class="grow muted">Creates a published release (no assets) and force-moves the major tag.</div>
+      <button id="publish" class="primary" disabled>Publish release</button>
+    </div>
+  </div>
+
+<script>
+const $ = (id) => document.getElementById(id);
+let state = { repo: "", suggested: {}, latestTag: "", footer: "", items: [], rawMode: false, rawText: "" };
+
+function showBanner(kind, html) {
+  const b = $("banner");
+  if (!kind) { b.innerHTML = ""; return; }
+  b.innerHTML = '<div class="banner ' + kind + '">' + html + '</div>';
+}
+
+function isValidTag(t) { return /^v\\d+\\.\\d+\\.\\d+$/.test(t); }
+
+function updateTagHint() {
+  const t = $("tag").value.trim();
+  const hint = $("tag-hint");
+  if (!t) { hint.textContent = ""; }
+  else if (!isValidTag(t)) { hint.textContent = "Must be v-prefixed semver, e.g. v4.2.1"; hint.style.color = "var(--true-color-red, #cf222e)"; }
+  else {
+    const major = "v" + t.slice(1).split(".")[0];
+    hint.textContent = "Will move major tag " + major + " to this release.";
+    hint.style.color = "";
+  }
+  refreshPublishEnabled();
+  refreshSegments();
+}
+
+function refreshSegments() {
+  const t = $("tag").value.trim();
+  document.querySelectorAll("button.seg").forEach((b) => {
+    b.classList.toggle("active", state.suggested[b.dataset.bump] === t);
+  });
+}
+
+function refreshPublishEnabled() {
+  $("publish").disabled = !isValidTag($("tag").value.trim());
+}
+
+function includedTexts() {
+  if (state.rawMode) return null;
+  return state.items.filter((i) => i.include).map((i) => i.text);
+}
+
+function composeBody() {
+  if (state.rawMode) return $("raw").value;
+  const inc = state.items.filter((i) => i.include).map((i) => i.text);
+  const parts = [];
+  if (inc.length) { parts.push("## What's Changed"); inc.forEach((t) => parts.push("* " + t)); }
+  if (state.footer) { if (parts.length) parts.push(""); parts.push(state.footer); }
+  return parts.join("\\n");
+}
+
+function badgeLabel(cat) {
+  return { "dependabot-dev": "dev dep", "dependabot-actions": "gh actions", "dependabot-prod": "prod dep", "change": "" }[cat] || "";
+}
+
+function renderItems() {
+  const ul = $("items");
+  ul.innerHTML = "";
+  state.items.forEach((item) => {
+    const li = document.createElement("li");
+    li.className = "item" + (item.include ? "" : " excluded");
+    const cb = document.createElement("input");
+    cb.type = "checkbox"; cb.checked = item.include;
+    cb.addEventListener("change", () => { item.include = cb.checked; li.classList.toggle("excluded", !cb.checked); });
+    const span = document.createElement("span");
+    span.className = "item-text"; span.textContent = item.text;
+    li.appendChild(cb); li.appendChild(span);
+    const lbl = badgeLabel(item.category);
+    if (lbl) {
+      const badge = document.createElement("span");
+      badge.className = "badge" + (item.category.startsWith("dependabot") ? " dep" : "");
+      badge.textContent = lbl;
+      li.appendChild(badge);
+    }
+    ul.appendChild(li);
+  });
+}
+
+async function loadStatus() {
+  try {
+    const r = await fetch("/api/status");
+    const s = await r.json();
+    if (s.error) throw new Error(s.error);
+    state.repo = s.repo;
+    state.suggested = s.suggested;
+    state.latestTag = s.latestRelease ? s.latestRelease.tagName : "";
+    $("subtitle").innerHTML = "Repository <span class='mono'>" + s.repo + "</span> · default branch <span class='mono'>" + s.defaultBranch + "</span>";
+    $("latest").textContent = s.latestRelease ? s.latestRelease.tagName : "(none)";
+    $("major").textContent = s.majorTag || "—";
+    $("tag").value = s.defaultTag || "";
+    $("title").value = s.defaultTag || "";
+    updateTagHint();
+  } catch (e) {
+    showBanner("err", "Failed to load repository status: " + e.message);
+  }
+}
+
+async function generate() {
+  const tag = $("tag").value.trim();
+  if (!isValidTag(tag)) { showBanner("err", "Enter a valid tag first."); return; }
+  showBanner(null);
+  $("regen").disabled = true; $("regen").textContent = "Generating…";
+  try {
+    const r = await fetch("/api/notes", {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ tag, previousTag: state.latestTag }),
+    });
+    const data = await r.json();
+    if (data.error) throw new Error(data.error);
+    state.items = data.items;
+    state.footer = data.footer;
+    state.rawMode = false;
+    $("raw").classList.add("hidden");
+    $("items").classList.remove("hidden");
+    $("toggle-edit").textContent = "Edit raw markdown";
+    $("notes-empty").classList.add("hidden");
+    $("notes-body").classList.remove("hidden");
+    renderItems();
+    if (!state.items.length) showBanner("ok", "No commits found between " + (state.latestTag || "start") + " and " + tag + ". You can still publish an empty release or edit the notes manually.");
+  } catch (e) {
+    showBanner("err", "Failed to generate notes: " + e.message);
+  } finally {
+    $("regen").disabled = false; $("regen").textContent = "Generate from commits";
+  }
+}
+
+async function publish() {
+  const tag = $("tag").value.trim();
+  const title = $("title").value.trim() || tag;
+  if (!isValidTag(tag)) { showBanner("err", "Enter a valid tag first."); return; }
+  const body = composeBody();
+  const major = "v" + tag.slice(1).split(".")[0];
+  if (!confirm("Publish release " + tag + " and force-move " + major + " to it?")) return;
+  showBanner(null);
+  $("publish").disabled = true; $("publish").textContent = "Publishing…";
+  try {
+    const r = await fetch("/api/publish", {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ tag, name: title, body }),
+    });
+    const data = await r.json();
+    if (data.error) throw new Error(data.error);
+    let msg = "Published <a href='" + data.releaseUrl + "' target='_blank'>" + data.tag + "</a>.";
+    if (data.movedMajor) msg += " Moved <span class='mono'>" + data.movedMajor.tag + "</span> → <span class='mono'>" + data.movedMajor.sha.slice(0,7) + "</span>.";
+    showBanner("ok", msg);
+    $("publish").textContent = "Published";
+  } catch (e) {
+    showBanner("err", "Publish failed: " + e.message);
+    $("publish").disabled = false; $("publish").textContent = "Publish release";
+  }
+}
+
+// Wiring
+document.querySelectorAll("button.seg").forEach((b) => b.addEventListener("click", () => {
+  const t = state.suggested[b.dataset.bump];
+  if (t) { $("tag").value = t; $("title").value = t; updateTagHint(); }
+}));
+$("tag").addEventListener("input", updateTagHint);
+$("regen").addEventListener("click", generate);
+$("publish").addEventListener("click", publish);
+$("check-all").addEventListener("click", () => { state.items.forEach((i) => i.include = true); renderItems(); });
+$("check-none").addEventListener("click", () => { state.items.forEach((i) => i.include = false); renderItems(); });
+$("toggle-edit").addEventListener("click", () => {
+  state.rawMode = !state.rawMode;
+  if (state.rawMode) {
+    $("raw").value = composeBody();
+    $("raw").classList.remove("hidden");
+    $("items").classList.add("hidden");
+    $("check-all").disabled = true; $("check-none").disabled = true;
+    $("toggle-edit").textContent = "Back to checklist";
+  } else {
+    $("raw").classList.add("hidden");
+    $("items").classList.remove("hidden");
+    $("check-all").disabled = false; $("check-none").disabled = false;
+    $("toggle-edit").textContent = "Edit raw markdown";
+  }
+});
+
+loadStatus();
+</script>
+</body>
+</html>`;
+}


### PR DESCRIPTION
## Summary

Adds a Copilot CLI canvas extension (`.github/extensions/release-cutter/`) that guides cutting a new release of the action, encoding this repo's release conventions.

<img width="604" height="589" alt="image" src="https://github.com/user-attachments/assets/c5665f64-7039-4bcf-8749-11af28c2c15e" />

## What it does

1. **Version** — shows the latest release and the floating major tag to move; patch/minor/major bump buttons prefill the next `v`-prefixed semver tag, with validation.
2. **Release notes** — pulls GitHub's auto-generated notes for the commit range into a checklist. Dependabot **dev-dependency** and **GitHub Actions** bumps are pre-unchecked; human changes and prod-dependency bumps stay checked. Supports select/clear all and raw-markdown editing.
3. **Publish** — creates the GitHub Release (**never a draft, never with assets**), then force-moves the major tag (e.g. `v4`) to the new release commit via the refs API.

## Files

- `extension.mjs` — canvas wiring + per-instance loopback HTTP server
- `backend.mjs` — `gh`/`git` logic, version math, dependabot classification
- `renderer.mjs` — iframe UI using app theme tokens

Also exposes three agent-callable actions (`get_status`, `generate_notes`, `publish_release`) so the release can be driven conversationally.

## Testing

Discovery, open, `get_status`, `generate_notes`, input-validation rejection, and reserved-verb rejection all verified against the live repo. The destructive `publish_release` path was not exercised (would create a real release); the create + tag-move logic is wired and ready.