### PR TITLE
fix: strip OCI image tag when pushing attestation to registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,13 +227,6 @@ Each entry must include a `name`, a `digest` in `algorithm:hex` format, and a
 When `push-to-registry` is enabled, the discovered artifacts list must contain
 exactly one subject and it must be an OCI-kind entry.
 
-For OCI-kind entries, any `:tag` in the `name` is preserved in the attestation
-subject but is stripped when the attestation is pushed to the registry — the
-entry's `digest` identifies the exact image, and the registry push requires a
-bare `registry/repository` reference. For example, a subject named
-`ghcr.io/owner/app:v1` is recorded in the attestation as-is, but the
-attestation is attached to `ghcr.io/owner/app` by digest.
-
 ## Examples
 
 ### Provenance Attestation (Default)

--- a/README.md
+++ b/README.md
@@ -227,10 +227,12 @@ Each entry must include a `name`, a `digest` in `algorithm:hex` format, and a
 When `push-to-registry` is enabled, the discovered artifacts list must contain
 exactly one subject and it must be an OCI-kind entry.
 
-For OCI-kind entries, any `:tag` in the `name` is ignored — the entry's
-`digest` identifies the exact image, so the subject name is normalized to a
-bare `registry/repository` reference (for example, `ghcr.io/owner/app:v1`
-becomes `ghcr.io/owner/app`).
+For OCI-kind entries, any `:tag` in the `name` is preserved in the attestation
+subject but is stripped when the attestation is pushed to the registry — the
+entry's `digest` identifies the exact image, and the registry push requires a
+bare `registry/repository` reference. For example, a subject named
+`ghcr.io/owner/app:v1` is recorded in the attestation as-is, but the
+attestation is attached to `ghcr.io/owner/app` by digest.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,11 @@ Each entry must include a `name`, a `digest` in `algorithm:hex` format, and a
 When `push-to-registry` is enabled, the discovered artifacts list must contain
 exactly one subject and it must be an OCI-kind entry.
 
+For OCI-kind entries, any `:tag` in the `name` is ignored — the entry's
+`digest` identifies the exact image, so the subject name is normalized to a
+bare `registry/repository` reference (for example, `ghcr.io/owner/app:v1`
+becomes `ghcr.io/owner/app`).
+
 ## Examples
 
 ### Provenance Attestation (Default)

--- a/__tests__/fixtures/mocks.ts
+++ b/__tests__/fixtures/mocks.ts
@@ -203,6 +203,13 @@ export const TEST_SUBJECT_WITH_REGISTRY: Subject = {
   }
 }
 
+export const TEST_SUBJECT_WITH_REGISTRY_TAG: Subject = {
+  name: 'ghcr.io/test-owner/test-repo:v1.2.3',
+  digest: {
+    sha256: '7d070f6b64d9bcc530fe99cc21eaaa4b3c364e0b2d367d7735671fa202a03b32'
+  }
+}
+
 export const TEST_PREDICATE: Predicate = {
   type: 'https://example.com/predicate/v1',
   params: { foo: 'bar' }

--- a/__tests__/integration/attest.test.ts
+++ b/__tests__/integration/attest.test.ts
@@ -4,7 +4,8 @@ import {
   createGitHubContextMock,
   createOctokitMock,
   TEST_PREDICATE,
-  TEST_SUBJECT_WITH_REGISTRY
+  TEST_SUBJECT_WITH_REGISTRY,
+  TEST_SUBJECT_WITH_REGISTRY_TAG
 } from '../fixtures/mocks'
 
 import type { Attestation } from '@actions/attest'
@@ -139,6 +140,24 @@ describe('createAttestation', () => {
 
       expect(mockAttachArtifactToImage).not.toHaveBeenCalled()
     })
+
+    it('should strip the image tag before pushing but keep it in the attestation subject', async () => {
+      const subjects = [TEST_SUBJECT_WITH_REGISTRY_TAG]
+
+      await createAttestation(subjects, TEST_PREDICATE, pushOpts)
+
+      // The attestation subject retains the tagged reference...
+      expect(mockAttest).toHaveBeenCalledWith(
+        expect.objectContaining({ subjects })
+      )
+      // ...but the registry-push path receives the bare reference.
+      expect(mockGetRegistryCredentials).toHaveBeenCalledWith(
+        'ghcr.io/test-owner/test-repo'
+      )
+      expect(mockAttachArtifactToImage).toHaveBeenCalledWith(
+        expect.objectContaining({ imageName: 'ghcr.io/test-owner/test-repo' })
+      )
+    })
   })
 
   describe('storage record creation', () => {
@@ -164,6 +183,20 @@ describe('createAttestation', () => {
         expect.anything()
       )
       expect(result.storageRecordIds).toEqual([12345])
+    })
+
+    it('should use the tag-stripped name in the storage record', async () => {
+      const subjects = [TEST_SUBJECT_WITH_REGISTRY_TAG]
+
+      await createAttestation(subjects, TEST_PREDICATE, storageOpts)
+
+      expect(mockCreateStorageRecord).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'ghcr.io/test-owner/test-repo' }),
+        expect.objectContaining({
+          registryUrl: 'https://ghcr.io'
+        }),
+        expect.anything()
+      )
     })
 
     it('should omit version from storage record when subjectVersion is empty', async () => {

--- a/__tests__/unit/artifacts.test.ts
+++ b/__tests__/unit/artifacts.test.ts
@@ -793,6 +793,18 @@ describe('parseArtifactsList', () => {
     it('should leave a reference with no colon unchanged', () => {
       expect(stripOCITag('ghcr.io/owner/app')).toBe('ghcr.io/owner/app')
     })
+
+    it('should leave a digest reference untouched', () => {
+      expect(stripOCITag(`ghcr.io/owner/app@sha256:${'a'.repeat(64)}`)).toBe(
+        `ghcr.io/owner/app@sha256:${'a'.repeat(64)}`
+      )
+    })
+
+    it('should leave a tag+digest reference untouched', () => {
+      expect(
+        stripOCITag(`ghcr.io/owner/app:v1@sha256:${'a'.repeat(64)}`)
+      ).toBe(`ghcr.io/owner/app:v1@sha256:${'a'.repeat(64)}`)
+    })
   })
 
   describe('requireSingleOCI option', () => {

--- a/__tests__/unit/artifacts.test.ts
+++ b/__tests__/unit/artifacts.test.ts
@@ -707,6 +707,122 @@ describe('parseArtifactsList', () => {
     })
   })
 
+  describe('OCI tag stripping', () => {
+    const wrap = (subjects: unknown[]): string =>
+      JSON.stringify({ version: 1, subjects })
+
+    it('should strip a trailing :tag from OCI names', () => {
+      const result = parseArtifactsList(
+        wrap([
+          {
+            name: 'ghcr.io/owner/app:12345',
+            kind: 'oci',
+            digest: `sha256:${'a'.repeat(64)}`
+          }
+        ])
+      )
+
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('ghcr.io/owner/app')
+    })
+
+    it('should preserve a registry port when no tag is present', () => {
+      const result = parseArtifactsList(
+        wrap([
+          {
+            name: 'localhost:5000/owner/app',
+            kind: 'oci',
+            digest: `sha256:${'a'.repeat(64)}`
+          }
+        ])
+      )
+
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('localhost:5000/owner/app')
+    })
+
+    it('should strip the tag but keep a registry port', () => {
+      const result = parseArtifactsList(
+        wrap([
+          {
+            name: 'localhost:5000/owner/app:12345',
+            kind: 'oci',
+            digest: `sha256:${'a'.repeat(64)}`
+          }
+        ])
+      )
+
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('localhost:5000/owner/app')
+    })
+
+    it('should leave OCI names without a tag unchanged', () => {
+      const result = parseArtifactsList(
+        wrap([
+          {
+            name: 'ghcr.io/owner/app',
+            kind: 'oci',
+            digest: `sha256:${'a'.repeat(64)}`
+          }
+        ])
+      )
+
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('ghcr.io/owner/app')
+    })
+
+    it('should NOT strip a colon from file-kind names', () => {
+      const result = parseArtifactsList(
+        wrap([
+          {
+            name: 'weird:name',
+            kind: 'file',
+            digest: `sha256:${'a'.repeat(64)}`
+          }
+        ])
+      )
+
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('weird:name')
+    })
+
+    it('should strip the tag then lowercase when downcaseOCI is true', () => {
+      const result = parseArtifactsList(
+        wrap([
+          {
+            name: 'ghcr.io/Owner/App:LatestBuild',
+            kind: 'oci',
+            digest: `sha256:${'a'.repeat(64)}`
+          }
+        ]),
+        { downcaseOCI: true }
+      )
+
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('ghcr.io/owner/app')
+    })
+
+    it('should collapse tag-only duplicate OCI names after stripping', () => {
+      const result = parseArtifactsList(
+        wrap([
+          {
+            name: 'ghcr.io/owner/app:v1',
+            kind: 'oci',
+            digest: `sha256:${'a'.repeat(64)}`
+          },
+          {
+            name: 'ghcr.io/owner/app:v2',
+            kind: 'oci',
+            digest: `sha256:${'a'.repeat(64)}`
+          }
+        ])
+      )
+
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('ghcr.io/owner/app')
+    })
+  })
+
   describe('requireSingleOCI option', () => {
     const wrap = (subjects: unknown[]): string =>
       JSON.stringify({ version: 1, subjects })

--- a/__tests__/unit/artifacts.test.ts
+++ b/__tests__/unit/artifacts.test.ts
@@ -5,7 +5,7 @@ import {
   errorMessage,
   readArtifactsList,
   parseArtifactsList,
-  stripOCITag
+  bareImageName
 } from '../../src/artifacts'
 
 const ENV_KEY = 'GITHUB_ARTIFACTS_LIST'
@@ -765,45 +765,49 @@ describe('parseArtifactsList', () => {
     })
   })
 
-  describe('stripOCITag', () => {
-    it('should strip a trailing :tag', () => {
-      expect(stripOCITag('ghcr.io/owner/app:12345')).toBe('ghcr.io/owner/app')
+  describe('bareImageName', () => {
+    const DIGEST = `sha256:${'a'.repeat(64)}`
+
+    it('should leave a bare reference unchanged', () => {
+      expect(bareImageName('ghcr.io/owner/app')).toBe('ghcr.io/owner/app')
     })
 
-    it('should leave a reference without a tag unchanged', () => {
-      expect(stripOCITag('ghcr.io/owner/app')).toBe('ghcr.io/owner/app')
+    it('should strip a trailing :tag', () => {
+      expect(bareImageName('ghcr.io/owner/app:12345')).toBe('ghcr.io/owner/app')
+    })
+
+    it('should strip a digest suffix', () => {
+      expect(bareImageName(`ghcr.io/owner/app@${DIGEST}`)).toBe(
+        'ghcr.io/owner/app'
+      )
+    })
+
+    it('should strip both a tag and a digest suffix', () => {
+      expect(bareImageName(`ghcr.io/owner/app:v1@${DIGEST}`)).toBe(
+        'ghcr.io/owner/app'
+      )
     })
 
     it('should preserve a registry port when no tag is present', () => {
-      expect(stripOCITag('localhost:5000/owner/app')).toBe(
+      expect(bareImageName('localhost:5000/owner/app')).toBe(
         'localhost:5000/owner/app'
       )
     })
 
     it('should strip the tag but keep a registry port', () => {
-      expect(stripOCITag('localhost:5000/owner/app:12345')).toBe(
+      expect(bareImageName('localhost:5000/owner/app:12345')).toBe(
+        'localhost:5000/owner/app'
+      )
+    })
+
+    it('should strip a digest but keep a registry port', () => {
+      expect(bareImageName(`localhost:5000/owner/app@${DIGEST}`)).toBe(
         'localhost:5000/owner/app'
       )
     })
 
     it('should strip a bare "name:tag" reference with no registry path', () => {
-      expect(stripOCITag('app:v1')).toBe('app')
-    })
-
-    it('should leave a reference with no colon unchanged', () => {
-      expect(stripOCITag('ghcr.io/owner/app')).toBe('ghcr.io/owner/app')
-    })
-
-    it('should leave a digest reference untouched', () => {
-      expect(stripOCITag(`ghcr.io/owner/app@sha256:${'a'.repeat(64)}`)).toBe(
-        `ghcr.io/owner/app@sha256:${'a'.repeat(64)}`
-      )
-    })
-
-    it('should leave a tag+digest reference untouched', () => {
-      expect(
-        stripOCITag(`ghcr.io/owner/app:v1@sha256:${'a'.repeat(64)}`)
-      ).toBe(`ghcr.io/owner/app:v1@sha256:${'a'.repeat(64)}`)
+      expect(bareImageName('app:v1')).toBe('app')
     })
   })
 

--- a/__tests__/unit/artifacts.test.ts
+++ b/__tests__/unit/artifacts.test.ts
@@ -4,7 +4,8 @@ import path from 'path'
 import {
   errorMessage,
   readArtifactsList,
-  parseArtifactsList
+  parseArtifactsList,
+  stripOCITag
 } from '../../src/artifacts'
 
 const ENV_KEY = 'GITHUB_ARTIFACTS_LIST'
@@ -707,11 +708,11 @@ describe('parseArtifactsList', () => {
     })
   })
 
-  describe('OCI tag stripping', () => {
+  describe('OCI tag preservation', () => {
     const wrap = (subjects: unknown[]): string =>
       JSON.stringify({ version: 1, subjects })
 
-    it('should strip a trailing :tag from OCI names', () => {
+    it('should preserve a trailing :tag in the OCI subject name', () => {
       const result = parseArtifactsList(
         wrap([
           {
@@ -723,74 +724,14 @@ describe('parseArtifactsList', () => {
       )
 
       expect(result).toHaveLength(1)
-      expect(result[0].name).toBe('ghcr.io/owner/app')
+      expect(result[0].name).toBe('ghcr.io/owner/app:12345')
     })
 
-    it('should preserve a registry port when no tag is present', () => {
+    it('should preserve the tag while lowercasing when downcaseOCI is true', () => {
       const result = parseArtifactsList(
         wrap([
           {
-            name: 'localhost:5000/owner/app',
-            kind: 'oci',
-            digest: `sha256:${'a'.repeat(64)}`
-          }
-        ])
-      )
-
-      expect(result).toHaveLength(1)
-      expect(result[0].name).toBe('localhost:5000/owner/app')
-    })
-
-    it('should strip the tag but keep a registry port', () => {
-      const result = parseArtifactsList(
-        wrap([
-          {
-            name: 'localhost:5000/owner/app:12345',
-            kind: 'oci',
-            digest: `sha256:${'a'.repeat(64)}`
-          }
-        ])
-      )
-
-      expect(result).toHaveLength(1)
-      expect(result[0].name).toBe('localhost:5000/owner/app')
-    })
-
-    it('should leave OCI names without a tag unchanged', () => {
-      const result = parseArtifactsList(
-        wrap([
-          {
-            name: 'ghcr.io/owner/app',
-            kind: 'oci',
-            digest: `sha256:${'a'.repeat(64)}`
-          }
-        ])
-      )
-
-      expect(result).toHaveLength(1)
-      expect(result[0].name).toBe('ghcr.io/owner/app')
-    })
-
-    it('should NOT strip a colon from file-kind names', () => {
-      const result = parseArtifactsList(
-        wrap([
-          {
-            name: 'weird:name',
-            kind: 'file',
-            digest: `sha256:${'a'.repeat(64)}`
-          }
-        ])
-      )
-
-      expect(result).toHaveLength(1)
-      expect(result[0].name).toBe('weird:name')
-    })
-
-    it('should strip the tag then lowercase when downcaseOCI is true', () => {
-      const result = parseArtifactsList(
-        wrap([
-          {
-            name: 'ghcr.io/Owner/App:LatestBuild',
+            name: 'ghcr.io/Owner/App:v1',
             kind: 'oci',
             digest: `sha256:${'a'.repeat(64)}`
           }
@@ -799,10 +740,10 @@ describe('parseArtifactsList', () => {
       )
 
       expect(result).toHaveLength(1)
-      expect(result[0].name).toBe('ghcr.io/owner/app')
+      expect(result[0].name).toBe('ghcr.io/owner/app:v1')
     })
 
-    it('should collapse tag-only duplicate OCI names after stripping', () => {
+    it('should treat differently-tagged OCI names as distinct subjects', () => {
       const result = parseArtifactsList(
         wrap([
           {
@@ -818,8 +759,39 @@ describe('parseArtifactsList', () => {
         ])
       )
 
-      expect(result).toHaveLength(1)
-      expect(result[0].name).toBe('ghcr.io/owner/app')
+      expect(result).toHaveLength(2)
+      expect(result[0].name).toBe('ghcr.io/owner/app:v1')
+      expect(result[1].name).toBe('ghcr.io/owner/app:v2')
+    })
+  })
+
+  describe('stripOCITag', () => {
+    it('should strip a trailing :tag', () => {
+      expect(stripOCITag('ghcr.io/owner/app:12345')).toBe('ghcr.io/owner/app')
+    })
+
+    it('should leave a reference without a tag unchanged', () => {
+      expect(stripOCITag('ghcr.io/owner/app')).toBe('ghcr.io/owner/app')
+    })
+
+    it('should preserve a registry port when no tag is present', () => {
+      expect(stripOCITag('localhost:5000/owner/app')).toBe(
+        'localhost:5000/owner/app'
+      )
+    })
+
+    it('should strip the tag but keep a registry port', () => {
+      expect(stripOCITag('localhost:5000/owner/app:12345')).toBe(
+        'localhost:5000/owner/app'
+      )
+    })
+
+    it('should strip a bare "name:tag" reference with no registry path', () => {
+      expect(stripOCITag('app:v1')).toBe('app')
+    })
+
+    it('should leave a reference with no colon unchanged', () => {
+      expect(stripOCITag('ghcr.io/owner/app')).toBe('ghcr.io/owner/app')
     })
   })
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -127813,6 +127813,18 @@ const HEX_RE = /^[0-9a-fA-F]+$/;
  */
 const errorMessage = (err) => err instanceof Error ? err.message : String(err);
 /**
+ * Removes a trailing ":tag" from an OCI image reference. The artifact's digest
+ * already pins the exact image, so a tag in the reference is redundant — and
+ * the registry-push path rejects any name that isn't a bare "registry/repo"
+ * reference. Only a colon appearing after the final path separator is treated
+ * as a tag, so a registry port (e.g. "localhost:5000/repo") is preserved.
+ */
+const stripOCITag = (name) => {
+    const lastSlash = name.lastIndexOf('/');
+    const lastColon = name.lastIndexOf(':');
+    return lastColon > lastSlash ? name.slice(0, lastColon) : name;
+};
+/**
  * Reads and parses the runner-generated artifacts list file identified by
  * the $GITHUB_ARTIFACTS_LIST environment variable. Returns undefined when
  * the env var is unset or blank (caller should treat this as "no discovered
@@ -127881,10 +127893,18 @@ const parseArtifactsList = (content, options) => {
         }
         const e = entry;
         const { name: rawName, kind, digest } = validateEntry(e, i);
-        // Normalize OCI names to lowercase when requested (e.g. for registry push).
-        // This must happen before dedup so that case-only duplicates collapse and
-        // case-colliding names with different digests are detected as conflicts.
-        const name = options?.downcaseOCI && kind === 'oci' ? rawName.toLowerCase() : rawName;
+        // Normalize OCI names before dedup so tag-only / case-only duplicates
+        // collapse and true conflicts are detected. Strip any ":tag" (the digest
+        // pins the exact image, and the registry-push path only accepts a bare
+        // "registry/repo" reference) and lowercase when requested (e.g. for
+        // registry push).
+        let name = rawName;
+        if (kind === 'oci') {
+            name = stripOCITag(name);
+            if (options?.downcaseOCI) {
+                name = name.toLowerCase();
+            }
+        }
         // Check for conflicts or duplicates by normalized name
         const prev = seen.get(name);
         if (prev) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -122344,9 +122344,14 @@ const errorMessage = (err) => err instanceof Error ? err.message : String(err);
  * the artifact's digest already pins the exact image, and the registry-push
  * path (@sigstore/oci) only accepts a bare reference. Only a colon appearing
  * after the final path separator is treated as a tag, so a registry port
- * (e.g. "localhost:5000/repo") is preserved.
+ * (e.g. "localhost:5000/repo") is preserved. A digest reference
+ * (e.g. "…/app@sha256:…") is left untouched — the ':' inside the digest is
+ * not a tag separator.
  */
 const stripOCITag = (name) => {
+    // Never treat a colon inside a digest ("@sha256:…") as a tag separator.
+    if (name.includes('@'))
+        return name;
     const lastSlash = name.lastIndexOf('/');
     const lastColon = name.lastIndexOf(':');
     return lastColon > lastSlash ? name.slice(0, lastColon) : name;

--- a/dist/index.js
+++ b/dist/index.js
@@ -122323,6 +122323,190 @@ function attestProvenance(options) {
 //# sourceMappingURL=index.js.map
 // EXTERNAL MODULE: ./node_modules/@sigstore/oci/dist/index.js
 var oci_dist = __nccwpck_require__(81057);
+;// CONCATENATED MODULE: ./src/artifacts.ts
+
+const ARTIFACTS_LIST_ENV = 'GITHUB_ARTIFACTS_LIST';
+const SUPPORTED_VERSION = 1;
+// Valid kinds and their allowed digest algorithms with expected hex lengths
+const DIGEST_RULES = {
+    file: { sha256: 64 },
+    oci: { sha256: 64 }
+};
+const HEX_RE = /^[0-9a-fA-F]+$/;
+/**
+ * Extracts a displayable message from an unknown caught value.
+ */
+const errorMessage = (err) => err instanceof Error ? err.message : String(err);
+/**
+ * Removes a trailing ":tag" from an OCI image reference, returning a bare
+ * "registry/repository" reference. The tag is preserved in the attestation
+ * subject but must be stripped before pushing the attestation to the registry:
+ * the artifact's digest already pins the exact image, and the registry-push
+ * path (@sigstore/oci) only accepts a bare reference. Only a colon appearing
+ * after the final path separator is treated as a tag, so a registry port
+ * (e.g. "localhost:5000/repo") is preserved.
+ */
+const stripOCITag = (name) => {
+    const lastSlash = name.lastIndexOf('/');
+    const lastColon = name.lastIndexOf(':');
+    return lastColon > lastSlash ? name.slice(0, lastColon) : name;
+};
+/**
+ * Reads and parses the runner-generated artifacts list file identified by
+ * the $GITHUB_ARTIFACTS_LIST environment variable. Returns undefined when
+ * the env var is unset or blank (caller should treat this as "no discovered
+ * subjects").
+ *
+ * Throws on any structural, encoding, or validation error so the caller
+ * surfaces a clear failure rather than silently producing an empty list.
+ */
+const readArtifactsList = async (options) => {
+    const filePath = process.env[ARTIFACTS_LIST_ENV];
+    if (!filePath || filePath.trim() === '') {
+        return undefined;
+    }
+    let raw;
+    try {
+        raw = await promises_default().readFile(filePath, 'utf-8');
+    }
+    catch (err) {
+        const msg = errorMessage(err);
+        throw new Error(`Failed to read artifacts list at "${filePath}": ${msg}`);
+    }
+    return parseArtifactsList(raw, options);
+};
+/**
+ * Parse and validate the JSON content of an artifacts list file.
+ */
+const parseArtifactsList = (content, options) => {
+    // Reject UTF-8 BOM (U+FEFF) — runner emits UTF-8 without BOM.
+    // Check before the whitespace test because String.prototype.trim()
+    // strips U+FEFF, so a BOM-only file would otherwise look empty.
+    if (content.charCodeAt(0) === 0xfeff) {
+        throw new Error('Artifacts list file contains a UTF-8 BOM; the file must be plain UTF-8');
+    }
+    // The runner intentionally leaves the file empty when the feature is off.
+    // Treat empty or whitespace-only content as "no discovered subjects".
+    if (content.trim() === '') {
+        return [];
+    }
+    let data;
+    try {
+        data = JSON.parse(content);
+    }
+    catch {
+        throw new Error('Artifacts list file contains invalid JSON');
+    }
+    if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+        throw new Error('Artifacts list must be a JSON object');
+    }
+    const obj = data;
+    // Version check
+    if (obj.version !== SUPPORTED_VERSION) {
+        throw new Error(`Unsupported artifacts list version: ${JSON.stringify(obj.version)} (expected ${SUPPORTED_VERSION})`);
+    }
+    // Subjects array
+    if (!Array.isArray(obj.subjects)) {
+        throw new Error('Artifacts list is missing a "subjects" array');
+    }
+    const entries = obj.subjects;
+    const subjects = [];
+    // Track (normalizedName, kind, digest) for dedup and conflict detection
+    const seen = new Map();
+    for (let i = 0; i < entries.length; i++) {
+        const entry = entries[i];
+        if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+            throw new Error(`Artifacts list entry ${i}: must be a JSON object`);
+        }
+        const e = entry;
+        const { name: rawName, kind, digest } = validateEntry(e, i);
+        // Normalize OCI names to lowercase when requested (e.g. for registry push).
+        // This must happen before dedup so that case-only duplicates collapse and
+        // case-colliding names with different digests are detected as conflicts.
+        // The image tag (if any) is intentionally preserved so it appears in the
+        // attestation subject; it is stripped later, only when the attestation is
+        // pushed to the registry (see stripOCITag usage in attest.ts).
+        const name = options?.downcaseOCI && kind === 'oci' ? rawName.toLowerCase() : rawName;
+        // Check for conflicts or duplicates by normalized name
+        const prev = seen.get(name);
+        if (prev) {
+            if (prev.kind === kind && prev.digest === digest) {
+                // Exact duplicate — skip silently
+                continue;
+            }
+            throw new Error(`Artifacts list entry ${i}: duplicate name "${name}" with conflicting kind or digest`);
+        }
+        seen.set(name, { kind, digest });
+        // Convert digest string "algorithm:hex" to Subject shape
+        const colonIdx = digest.indexOf(':');
+        const algorithm = digest.slice(0, colonIdx);
+        const hex = digest.slice(colonIdx + 1);
+        subjects.push({
+            name,
+            digest: { [algorithm]: hex }
+        });
+    }
+    // When requireSingleOCI is set (registry push flow), enforce that exactly
+    // one subject was discovered and that it is OCI-kind. This prevents file
+    // subjects from leaking into the registry push path.
+    if (options?.requireSingleOCI && subjects.length > 0) {
+        // Re-check kinds from the validated entries — we tracked them in `seen`
+        const kinds = [...seen.values()].map(v => v.kind);
+        const hasNonOCI = kinds.some(k => k !== 'oci');
+        if (hasNonOCI) {
+            throw new Error('push-to-registry requires an OCI subject but the discovered artifacts list contains file-kind subjects');
+        }
+        if (subjects.length > 1) {
+            throw new Error('push-to-registry requires exactly one subject but the discovered artifacts list contains multiple subjects');
+        }
+    }
+    return subjects;
+};
+/**
+ * Validate a single entry from the artifacts list. Returns the validated
+ * name, kind, and digest string on success; throws with a contextual
+ * message on failure.
+ */
+const validateEntry = (entry, index) => {
+    // name
+    if (typeof entry.name !== 'string' || entry.name === '') {
+        throw new Error(`Artifacts list entry ${index}: "name" must be a non-empty string`);
+    }
+    const name = entry.name;
+    // kind
+    if (typeof entry.kind !== 'string') {
+        throw new Error(`Artifacts list entry ${index}: "kind" must be a string`);
+    }
+    const kind = entry.kind;
+    const allowedAlgorithms = DIGEST_RULES[kind];
+    if (!allowedAlgorithms) {
+        throw new Error(`Artifacts list entry ${index}: unsupported kind "${kind}" (expected "file" or "oci")`);
+    }
+    // digest — must be "algorithm:hex"
+    if (typeof entry.digest !== 'string' || entry.digest === '') {
+        throw new Error(`Artifacts list entry ${index}: "digest" must be a non-empty string`);
+    }
+    const digest = entry.digest;
+    const colonIdx = digest.indexOf(':');
+    if (colonIdx === -1) {
+        throw new Error(`Artifacts list entry ${index}: digest must be in the format "algorithm:hex"`);
+    }
+    const algorithm = digest.slice(0, colonIdx);
+    const hex = digest.slice(colonIdx + 1);
+    const expectedLen = allowedAlgorithms[algorithm];
+    if (expectedLen === undefined) {
+        const allowed = Object.keys(allowedAlgorithms).join(', ');
+        throw new Error(`Artifacts list entry ${index}: algorithm "${algorithm}" is not allowed for kind "${kind}" (allowed: ${allowed})`);
+    }
+    if (!HEX_RE.test(hex)) {
+        throw new Error(`Artifacts list entry ${index}: digest contains invalid hex characters`);
+    }
+    if (hex.length !== expectedLen) {
+        throw new Error(`Artifacts list entry ${index}: digest has ${hex.length} hex characters but "${algorithm}" requires exactly ${expectedLen}`);
+    }
+    return { name, kind, digest };
+};
+
 ;// CONCATENATED MODULE: ./node_modules/@actions/glob/lib/internal-glob-options-helper.js
 
 /**
@@ -127798,193 +127982,6 @@ const sync_parse = function (data, opts = {}) {
 
 
 
-;// CONCATENATED MODULE: ./src/artifacts.ts
-
-const ARTIFACTS_LIST_ENV = 'GITHUB_ARTIFACTS_LIST';
-const SUPPORTED_VERSION = 1;
-// Valid kinds and their allowed digest algorithms with expected hex lengths
-const DIGEST_RULES = {
-    file: { sha256: 64 },
-    oci: { sha256: 64 }
-};
-const HEX_RE = /^[0-9a-fA-F]+$/;
-/**
- * Extracts a displayable message from an unknown caught value.
- */
-const errorMessage = (err) => err instanceof Error ? err.message : String(err);
-/**
- * Removes a trailing ":tag" from an OCI image reference. The artifact's digest
- * already pins the exact image, so a tag in the reference is redundant — and
- * the registry-push path rejects any name that isn't a bare "registry/repo"
- * reference. Only a colon appearing after the final path separator is treated
- * as a tag, so a registry port (e.g. "localhost:5000/repo") is preserved.
- */
-const stripOCITag = (name) => {
-    const lastSlash = name.lastIndexOf('/');
-    const lastColon = name.lastIndexOf(':');
-    return lastColon > lastSlash ? name.slice(0, lastColon) : name;
-};
-/**
- * Reads and parses the runner-generated artifacts list file identified by
- * the $GITHUB_ARTIFACTS_LIST environment variable. Returns undefined when
- * the env var is unset or blank (caller should treat this as "no discovered
- * subjects").
- *
- * Throws on any structural, encoding, or validation error so the caller
- * surfaces a clear failure rather than silently producing an empty list.
- */
-const readArtifactsList = async (options) => {
-    const filePath = process.env[ARTIFACTS_LIST_ENV];
-    if (!filePath || filePath.trim() === '') {
-        return undefined;
-    }
-    let raw;
-    try {
-        raw = await promises_default().readFile(filePath, 'utf-8');
-    }
-    catch (err) {
-        const msg = errorMessage(err);
-        throw new Error(`Failed to read artifacts list at "${filePath}": ${msg}`);
-    }
-    return parseArtifactsList(raw, options);
-};
-/**
- * Parse and validate the JSON content of an artifacts list file.
- */
-const parseArtifactsList = (content, options) => {
-    // Reject UTF-8 BOM (U+FEFF) — runner emits UTF-8 without BOM.
-    // Check before the whitespace test because String.prototype.trim()
-    // strips U+FEFF, so a BOM-only file would otherwise look empty.
-    if (content.charCodeAt(0) === 0xfeff) {
-        throw new Error('Artifacts list file contains a UTF-8 BOM; the file must be plain UTF-8');
-    }
-    // The runner intentionally leaves the file empty when the feature is off.
-    // Treat empty or whitespace-only content as "no discovered subjects".
-    if (content.trim() === '') {
-        return [];
-    }
-    let data;
-    try {
-        data = JSON.parse(content);
-    }
-    catch {
-        throw new Error('Artifacts list file contains invalid JSON');
-    }
-    if (typeof data !== 'object' || data === null || Array.isArray(data)) {
-        throw new Error('Artifacts list must be a JSON object');
-    }
-    const obj = data;
-    // Version check
-    if (obj.version !== SUPPORTED_VERSION) {
-        throw new Error(`Unsupported artifacts list version: ${JSON.stringify(obj.version)} (expected ${SUPPORTED_VERSION})`);
-    }
-    // Subjects array
-    if (!Array.isArray(obj.subjects)) {
-        throw new Error('Artifacts list is missing a "subjects" array');
-    }
-    const entries = obj.subjects;
-    const subjects = [];
-    // Track (normalizedName, kind, digest) for dedup and conflict detection
-    const seen = new Map();
-    for (let i = 0; i < entries.length; i++) {
-        const entry = entries[i];
-        if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
-            throw new Error(`Artifacts list entry ${i}: must be a JSON object`);
-        }
-        const e = entry;
-        const { name: rawName, kind, digest } = validateEntry(e, i);
-        // Normalize OCI names before dedup so tag-only / case-only duplicates
-        // collapse and true conflicts are detected. Strip any ":tag" (the digest
-        // pins the exact image, and the registry-push path only accepts a bare
-        // "registry/repo" reference) and lowercase when requested (e.g. for
-        // registry push).
-        let name = rawName;
-        if (kind === 'oci') {
-            name = stripOCITag(name);
-            if (options?.downcaseOCI) {
-                name = name.toLowerCase();
-            }
-        }
-        // Check for conflicts or duplicates by normalized name
-        const prev = seen.get(name);
-        if (prev) {
-            if (prev.kind === kind && prev.digest === digest) {
-                // Exact duplicate — skip silently
-                continue;
-            }
-            throw new Error(`Artifacts list entry ${i}: duplicate name "${name}" with conflicting kind or digest`);
-        }
-        seen.set(name, { kind, digest });
-        // Convert digest string "algorithm:hex" to Subject shape
-        const colonIdx = digest.indexOf(':');
-        const algorithm = digest.slice(0, colonIdx);
-        const hex = digest.slice(colonIdx + 1);
-        subjects.push({
-            name,
-            digest: { [algorithm]: hex }
-        });
-    }
-    // When requireSingleOCI is set (registry push flow), enforce that exactly
-    // one subject was discovered and that it is OCI-kind. This prevents file
-    // subjects from leaking into the registry push path.
-    if (options?.requireSingleOCI && subjects.length > 0) {
-        // Re-check kinds from the validated entries — we tracked them in `seen`
-        const kinds = [...seen.values()].map(v => v.kind);
-        const hasNonOCI = kinds.some(k => k !== 'oci');
-        if (hasNonOCI) {
-            throw new Error('push-to-registry requires an OCI subject but the discovered artifacts list contains file-kind subjects');
-        }
-        if (subjects.length > 1) {
-            throw new Error('push-to-registry requires exactly one subject but the discovered artifacts list contains multiple subjects');
-        }
-    }
-    return subjects;
-};
-/**
- * Validate a single entry from the artifacts list. Returns the validated
- * name, kind, and digest string on success; throws with a contextual
- * message on failure.
- */
-const validateEntry = (entry, index) => {
-    // name
-    if (typeof entry.name !== 'string' || entry.name === '') {
-        throw new Error(`Artifacts list entry ${index}: "name" must be a non-empty string`);
-    }
-    const name = entry.name;
-    // kind
-    if (typeof entry.kind !== 'string') {
-        throw new Error(`Artifacts list entry ${index}: "kind" must be a string`);
-    }
-    const kind = entry.kind;
-    const allowedAlgorithms = DIGEST_RULES[kind];
-    if (!allowedAlgorithms) {
-        throw new Error(`Artifacts list entry ${index}: unsupported kind "${kind}" (expected "file" or "oci")`);
-    }
-    // digest — must be "algorithm:hex"
-    if (typeof entry.digest !== 'string' || entry.digest === '') {
-        throw new Error(`Artifacts list entry ${index}: "digest" must be a non-empty string`);
-    }
-    const digest = entry.digest;
-    const colonIdx = digest.indexOf(':');
-    if (colonIdx === -1) {
-        throw new Error(`Artifacts list entry ${index}: digest must be in the format "algorithm:hex"`);
-    }
-    const algorithm = digest.slice(0, colonIdx);
-    const hex = digest.slice(colonIdx + 1);
-    const expectedLen = allowedAlgorithms[algorithm];
-    if (expectedLen === undefined) {
-        const allowed = Object.keys(allowedAlgorithms).join(', ');
-        throw new Error(`Artifacts list entry ${index}: algorithm "${algorithm}" is not allowed for kind "${kind}" (allowed: ${allowed})`);
-    }
-    if (!HEX_RE.test(hex)) {
-        throw new Error(`Artifacts list entry ${index}: digest contains invalid hex characters`);
-    }
-    if (hex.length !== expectedLen) {
-        throw new Error(`Artifacts list entry ${index}: digest has ${hex.length} hex characters but "${algorithm}" requires exactly ${expectedLen}`);
-    }
-    return { name, kind, digest };
-};
-
 ;// CONCATENATED MODULE: ./src/subject.ts
 
 
@@ -128222,6 +128219,7 @@ const digestAlgorithm = (digest) => {
 
 
 
+
 const OCI_TIMEOUT = 30000;
 const OCI_RETRY = 3;
 const createAttestation = async (subjects, predicate, opts) => {
@@ -128236,11 +128234,15 @@ const createAttestation = async (subjects, predicate, opts) => {
     const result = attestation;
     if (subjects.length === 1 && opts.pushToRegistry) {
         const subject = subjects[0];
-        const credentials = (0,oci_dist/* getRegistryCredentials */.U2)(subject.name);
+        // The attestation subject may carry an image tag (e.g. "…/app:v1"), but
+        // the registry-push APIs require a bare "registry/repository" reference.
+        // Strip the tag here; the subject digest still pins the exact image.
+        const imageName = stripOCITag(subject.name);
+        const credentials = (0,oci_dist/* getRegistryCredentials */.U2)(imageName);
         const subjectDigest = formatSubjectDigest(subject);
         const artifact = await (0,oci_dist/* attachArtifactToImage */.Kg)({
             credentials,
-            imageName: subject.name,
+            imageName,
             imageDigest: subjectDigest,
             artifact: Buffer.from(JSON.stringify(attestation.bundle)),
             mediaType: attestation.bundle.mediaType,
@@ -128265,9 +128267,9 @@ const createAttestation = async (subjects, predicate, opts) => {
                     // storage record creation should not be attempted.
                     return result;
                 }
-                const registryUrl = getRegistryURL(subject.name);
+                const registryUrl = getRegistryURL(imageName);
                 const artifactOpts = {
-                    name: subject.name,
+                    name: imageName,
                     digest: subjectDigest,
                     version: opts.subjectVersion || undefined
                 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -122338,23 +122338,30 @@ const HEX_RE = /^[0-9a-fA-F]+$/;
  */
 const errorMessage = (err) => err instanceof Error ? err.message : String(err);
 /**
- * Removes a trailing ":tag" from an OCI image reference, returning a bare
- * "registry/repository" reference. The tag is preserved in the attestation
- * subject but must be stripped before pushing the attestation to the registry:
- * the artifact's digest already pins the exact image, and the registry-push
- * path (@sigstore/oci) only accepts a bare reference. Only a colon appearing
- * after the final path separator is treated as a tag, so a registry port
- * (e.g. "localhost:5000/repo") is preserved. A digest reference
- * (e.g. "…/app@sha256:…") is left untouched — the ':' inside the digest is
- * not a tag separator.
+ * Reduces an OCI image reference to a bare "registry/repository" reference by
+ * removing any tag and/or digest suffix. A tag or digest is preserved in the
+ * attestation subject but must be stripped before pushing the attestation to
+ * the registry: the subject's digest already pins the exact image, and the
+ * registry-push path (@sigstore/oci) only accepts a bare reference.
+ *
+ * Handles every reference form:
+ *   - foo/bar              -> foo/bar
+ *   - foo/bar:tag          -> foo/bar
+ *   - foo/bar@sha256:…      -> foo/bar
+ *   - foo/bar:tag@sha256:…  -> foo/bar
+ *
+ * A registry port (e.g. "localhost:5000/repo") is preserved, since only a
+ * colon appearing after the final path separator is treated as a tag.
  */
-const stripOCITag = (name) => {
-    // Never treat a colon inside a digest ("@sha256:…") as a tag separator.
-    if (name.includes('@'))
-        return name;
-    const lastSlash = name.lastIndexOf('/');
-    const lastColon = name.lastIndexOf(':');
-    return lastColon > lastSlash ? name.slice(0, lastColon) : name;
+const bareImageName = (name) => {
+    // Drop a digest suffix ("@sha256:…") first, if present.
+    const atIndex = name.indexOf('@');
+    const ref = atIndex === -1 ? name : name.slice(0, atIndex);
+    // Then drop a tag suffix (":tag"), but not a registry port (a colon that
+    // appears before the final path separator).
+    const lastSlash = ref.lastIndexOf('/');
+    const lastColon = ref.lastIndexOf(':');
+    return lastColon > lastSlash ? ref.slice(0, lastColon) : ref;
 };
 /**
  * Reads and parses the runner-generated artifacts list file identified by
@@ -122430,7 +122437,7 @@ const parseArtifactsList = (content, options) => {
         // case-colliding names with different digests are detected as conflicts.
         // The image tag (if any) is intentionally preserved so it appears in the
         // attestation subject; it is stripped later, only when the attestation is
-        // pushed to the registry (see stripOCITag usage in attest.ts).
+        // pushed to the registry (see bareImageName usage in attest.ts).
         const name = options?.downcaseOCI && kind === 'oci' ? rawName.toLowerCase() : rawName;
         // Check for conflicts or duplicates by normalized name
         const prev = seen.get(name);
@@ -128239,10 +128246,11 @@ const createAttestation = async (subjects, predicate, opts) => {
     const result = attestation;
     if (subjects.length === 1 && opts.pushToRegistry) {
         const subject = subjects[0];
-        // The attestation subject may carry an image tag (e.g. "…/app:v1"), but
-        // the registry-push APIs require a bare "registry/repository" reference.
-        // Strip the tag here; the subject digest still pins the exact image.
-        const imageName = stripOCITag(subject.name);
+        // The attestation subject may carry a tag and/or digest
+        // (e.g. "…/app:v1" or "…/app:v1@sha256:…"), but the registry-push APIs
+        // require a bare "registry/repository" reference. Reduce it here; the
+        // subject digest still pins the exact image.
+        const imageName = bareImageName(subject.name);
         const credentials = (0,oci_dist/* getRegistryCredentials */.U2)(imageName);
         const subjectDigest = formatSubjectDigest(subject);
         const artifact = await (0,oci_dist/* attachArtifactToImage */.Kg)({

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -36,6 +36,19 @@ export const errorMessage = (err: unknown): string =>
   err instanceof Error ? err.message : String(err)
 
 /**
+ * Removes a trailing ":tag" from an OCI image reference. The artifact's digest
+ * already pins the exact image, so a tag in the reference is redundant — and
+ * the registry-push path rejects any name that isn't a bare "registry/repo"
+ * reference. Only a colon appearing after the final path separator is treated
+ * as a tag, so a registry port (e.g. "localhost:5000/repo") is preserved.
+ */
+export const stripOCITag = (name: string): string => {
+  const lastSlash = name.lastIndexOf('/')
+  const lastColon = name.lastIndexOf(':')
+  return lastColon > lastSlash ? name.slice(0, lastColon) : name
+}
+
+/**
  * Reads and parses the runner-generated artifacts list file identified by
  * the $GITHUB_ARTIFACTS_LIST environment variable. Returns undefined when
  * the env var is unset or blank (caller should treat this as "no discovered
@@ -125,11 +138,18 @@ export const parseArtifactsList = (
     const e = entry as Record<string, unknown>
     const { name: rawName, kind, digest } = validateEntry(e, i)
 
-    // Normalize OCI names to lowercase when requested (e.g. for registry push).
-    // This must happen before dedup so that case-only duplicates collapse and
-    // case-colliding names with different digests are detected as conflicts.
-    const name =
-      options?.downcaseOCI && kind === 'oci' ? rawName.toLowerCase() : rawName
+    // Normalize OCI names before dedup so tag-only / case-only duplicates
+    // collapse and true conflicts are detected. Strip any ":tag" (the digest
+    // pins the exact image, and the registry-push path only accepts a bare
+    // "registry/repo" reference) and lowercase when requested (e.g. for
+    // registry push).
+    let name = rawName
+    if (kind === 'oci') {
+      name = stripOCITag(name)
+      if (options?.downcaseOCI) {
+        name = name.toLowerCase()
+      }
+    }
 
     // Check for conflicts or duplicates by normalized name
     const prev = seen.get(name)

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -36,22 +36,30 @@ export const errorMessage = (err: unknown): string =>
   err instanceof Error ? err.message : String(err)
 
 /**
- * Removes a trailing ":tag" from an OCI image reference, returning a bare
- * "registry/repository" reference. The tag is preserved in the attestation
- * subject but must be stripped before pushing the attestation to the registry:
- * the artifact's digest already pins the exact image, and the registry-push
- * path (@sigstore/oci) only accepts a bare reference. Only a colon appearing
- * after the final path separator is treated as a tag, so a registry port
- * (e.g. "localhost:5000/repo") is preserved. A digest reference
- * (e.g. "…/app@sha256:…") is left untouched — the ':' inside the digest is
- * not a tag separator.
+ * Reduces an OCI image reference to a bare "registry/repository" reference by
+ * removing any tag and/or digest suffix. A tag or digest is preserved in the
+ * attestation subject but must be stripped before pushing the attestation to
+ * the registry: the subject's digest already pins the exact image, and the
+ * registry-push path (@sigstore/oci) only accepts a bare reference.
+ *
+ * Handles every reference form:
+ *   - foo/bar              -> foo/bar
+ *   - foo/bar:tag          -> foo/bar
+ *   - foo/bar@sha256:…      -> foo/bar
+ *   - foo/bar:tag@sha256:…  -> foo/bar
+ *
+ * A registry port (e.g. "localhost:5000/repo") is preserved, since only a
+ * colon appearing after the final path separator is treated as a tag.
  */
-export const stripOCITag = (name: string): string => {
-  // Never treat a colon inside a digest ("@sha256:…") as a tag separator.
-  if (name.includes('@')) return name
-  const lastSlash = name.lastIndexOf('/')
-  const lastColon = name.lastIndexOf(':')
-  return lastColon > lastSlash ? name.slice(0, lastColon) : name
+export const bareImageName = (name: string): string => {
+  // Drop a digest suffix ("@sha256:…") first, if present.
+  const atIndex = name.indexOf('@')
+  const ref = atIndex === -1 ? name : name.slice(0, atIndex)
+  // Then drop a tag suffix (":tag"), but not a registry port (a colon that
+  // appears before the final path separator).
+  const lastSlash = ref.lastIndexOf('/')
+  const lastColon = ref.lastIndexOf(':')
+  return lastColon > lastSlash ? ref.slice(0, lastColon) : ref
 }
 
 /**
@@ -149,7 +157,7 @@ export const parseArtifactsList = (
     // case-colliding names with different digests are detected as conflicts.
     // The image tag (if any) is intentionally preserved so it appears in the
     // attestation subject; it is stripped later, only when the attestation is
-    // pushed to the registry (see stripOCITag usage in attest.ts).
+    // pushed to the registry (see bareImageName usage in attest.ts).
     const name =
       options?.downcaseOCI && kind === 'oci' ? rawName.toLowerCase() : rawName
 

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -36,11 +36,13 @@ export const errorMessage = (err: unknown): string =>
   err instanceof Error ? err.message : String(err)
 
 /**
- * Removes a trailing ":tag" from an OCI image reference. The artifact's digest
- * already pins the exact image, so a tag in the reference is redundant — and
- * the registry-push path rejects any name that isn't a bare "registry/repo"
- * reference. Only a colon appearing after the final path separator is treated
- * as a tag, so a registry port (e.g. "localhost:5000/repo") is preserved.
+ * Removes a trailing ":tag" from an OCI image reference, returning a bare
+ * "registry/repository" reference. The tag is preserved in the attestation
+ * subject but must be stripped before pushing the attestation to the registry:
+ * the artifact's digest already pins the exact image, and the registry-push
+ * path (@sigstore/oci) only accepts a bare reference. Only a colon appearing
+ * after the final path separator is treated as a tag, so a registry port
+ * (e.g. "localhost:5000/repo") is preserved.
  */
 export const stripOCITag = (name: string): string => {
   const lastSlash = name.lastIndexOf('/')
@@ -138,18 +140,14 @@ export const parseArtifactsList = (
     const e = entry as Record<string, unknown>
     const { name: rawName, kind, digest } = validateEntry(e, i)
 
-    // Normalize OCI names before dedup so tag-only / case-only duplicates
-    // collapse and true conflicts are detected. Strip any ":tag" (the digest
-    // pins the exact image, and the registry-push path only accepts a bare
-    // "registry/repo" reference) and lowercase when requested (e.g. for
-    // registry push).
-    let name = rawName
-    if (kind === 'oci') {
-      name = stripOCITag(name)
-      if (options?.downcaseOCI) {
-        name = name.toLowerCase()
-      }
-    }
+    // Normalize OCI names to lowercase when requested (e.g. for registry push).
+    // This must happen before dedup so that case-only duplicates collapse and
+    // case-colliding names with different digests are detected as conflicts.
+    // The image tag (if any) is intentionally preserved so it appears in the
+    // attestation subject; it is stripped later, only when the attestation is
+    // pushed to the registry (see stripOCITag usage in attest.ts).
+    const name =
+      options?.downcaseOCI && kind === 'oci' ? rawName.toLowerCase() : rawName
 
     // Check for conflicts or duplicates by normalized name
     const prev = seen.get(name)

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -42,9 +42,13 @@ export const errorMessage = (err: unknown): string =>
  * the artifact's digest already pins the exact image, and the registry-push
  * path (@sigstore/oci) only accepts a bare reference. Only a colon appearing
  * after the final path separator is treated as a tag, so a registry port
- * (e.g. "localhost:5000/repo") is preserved.
+ * (e.g. "localhost:5000/repo") is preserved. A digest reference
+ * (e.g. "…/app@sha256:…") is left untouched — the ':' inside the digest is
+ * not a tag separator.
  */
 export const stripOCITag = (name: string): string => {
+  // Never treat a colon inside a digest ("@sha256:…") as a tag separator.
+  if (name.includes('@')) return name
   const lastSlash = name.lastIndexOf('/')
   const lastColon = name.lastIndexOf(':')
   return lastColon > lastSlash ? name.slice(0, lastColon) : name

--- a/src/attest.ts
+++ b/src/attest.ts
@@ -8,6 +8,7 @@ import {
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 import { attachArtifactToImage, getRegistryCredentials } from '@sigstore/oci'
+import { stripOCITag } from './artifacts'
 import { formatSubjectDigest } from './subject'
 
 const OCI_TIMEOUT = 30000
@@ -43,11 +44,15 @@ export const createAttestation = async (
 
   if (subjects.length === 1 && opts.pushToRegistry) {
     const subject = subjects[0]
-    const credentials = getRegistryCredentials(subject.name)
+    // The attestation subject may carry an image tag (e.g. "…/app:v1"), but
+    // the registry-push APIs require a bare "registry/repository" reference.
+    // Strip the tag here; the subject digest still pins the exact image.
+    const imageName = stripOCITag(subject.name)
+    const credentials = getRegistryCredentials(imageName)
     const subjectDigest = formatSubjectDigest(subject)
     const artifact = await attachArtifactToImage({
       credentials,
-      imageName: subject.name,
+      imageName,
       imageDigest: subjectDigest,
       artifact: Buffer.from(JSON.stringify(attestation.bundle)),
       mediaType: attestation.bundle.mediaType,
@@ -75,9 +80,9 @@ export const createAttestation = async (
           return result
         }
 
-        const registryUrl = getRegistryURL(subject.name)
+        const registryUrl = getRegistryURL(imageName)
         const artifactOpts = {
-          name: subject.name,
+          name: imageName,
           digest: subjectDigest,
           version: opts.subjectVersion || undefined
         }

--- a/src/attest.ts
+++ b/src/attest.ts
@@ -8,7 +8,7 @@ import {
 import * as core from '@actions/core'
 import * as github from '@actions/github'
 import { attachArtifactToImage, getRegistryCredentials } from '@sigstore/oci'
-import { stripOCITag } from './artifacts'
+import { bareImageName } from './artifacts'
 import { formatSubjectDigest } from './subject'
 
 const OCI_TIMEOUT = 30000
@@ -44,10 +44,11 @@ export const createAttestation = async (
 
   if (subjects.length === 1 && opts.pushToRegistry) {
     const subject = subjects[0]
-    // The attestation subject may carry an image tag (e.g. "…/app:v1"), but
-    // the registry-push APIs require a bare "registry/repository" reference.
-    // Strip the tag here; the subject digest still pins the exact image.
-    const imageName = stripOCITag(subject.name)
+    // The attestation subject may carry a tag and/or digest
+    // (e.g. "…/app:v1" or "…/app:v1@sha256:…"), but the registry-push APIs
+    // require a bare "registry/repository" reference. Reduce it here; the
+    // subject digest still pins the exact image.
+    const imageName = bareImageName(subject.name)
     const credentials = getRegistryCredentials(imageName)
     const subjectDigest = formatSubjectDigest(subject)
     const artifact = await attachArtifactToImage({


### PR DESCRIPTION
## Summary

When a subject is discovered via `$GITHUB_ARTIFACTS_LIST` for an OCI image, the
`name` may include a `:tag` (e.g. `ghcr.io/owner/app:v1`). Pushing the
attestation to the registry via `@sigstore/oci` fails on such names because
`parseImageName` only accepts a bare `registry/repository` reference:

```
Invalid image name: ghcr.io/github/attest-demo:30468266162
```

## Approach

The image tag is **preserved in the attestation subject** (it's meaningful
provenance) and **stripped only at the registry-push boundary** in `attest.ts`.
The subject digest already pins the exact image, so a bare reference is
sufficient for attaching/pushing the attestation.

- `parseArtifactsList` now records OCI subjects faithfully (tag preserved;
  `downcaseOCI` still applied for the push flow).
- `stripOCITag` is applied in `createAttestation` for `getRegistryCredentials`,
  `attachArtifactToImage`, `getRegistryURL`, and the storage record — so the
  signed attestation keeps `…/app:v1` while the push targets `…/app`.
- Only a colon after the final `/` is treated as a tag, so a registry port
  (e.g. `localhost:5000/repo`) is preserved.

## Testing

- Unit tests for `stripOCITag` (tag stripping, port preservation, no-op cases)
  and tag-preservation in parse output.
- Integration tests asserting the attestation subject retains the tag while the
  registry-push path and storage record receive the stripped name.
- Full suite green at 100% coverage; `dist/` regenerated.